### PR TITLE
fixed Y-axis in mark-to-base positioning

### DIFF
--- a/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
@@ -639,7 +639,7 @@ namespace Typography.OpenFont.Tables
 
                                 }
 #endif
-                                glyphPos.yoffset += markAnchorPoint.ycoord;
+                                glyphPos.yoffset += basePointForMark.ycoord - markAnchorPoint.ycoord;
 
                             }
                         }


### PR DESCRIPTION
Take Y coordinate of anchor position of base glyph into account, in addition to the Y coordinate of the mark glyph's anchor position.

This is similar to what is done for the X coordinate.

This is required for proper rendering of certain Hebrew diacritics. For example, in the [Alef font](http://alef.hagilda.com/), for the character HEBREW LETTER FINAL KAF (unicode code point 0x05da), diacritics rendered underneath letters should be rendered well above the normal height used for other letters (see below for proper rendering).

<img width="209" alt="screen shot 2017-04-13 at 14 17 58" src="https://cloud.githubusercontent.com/assets/532281/25002628/1a736618-2054-11e7-8875-4b850917b0f6.png">
