### PR TITLE
Warn about some unimplemented features instead of throwing.

### DIFF
--- a/Typography.OpenFont/CharacterMap.cs
+++ b/Typography.OpenFont/CharacterMap.cs
@@ -64,8 +64,6 @@ namespace Typography.OpenFont
         }
     }
 
-
-
     class CharMapFormat12 : CharacterMap
     {
         uint[] startCharCodes, endCharCodes, startGlyphIds;
@@ -75,13 +73,15 @@ namespace Typography.OpenFont
             this.startCharCodes = startCharCodes;
             this.endCharCodes = endCharCodes;
             this.startGlyphIds = startGlyphIds;
-
         }
+
         protected override ushort RawCharacterToGlyphIndex(ushort character)
         {
-            throw new NotImplementedException();
+            Utils.WarnUnimplemented("cmap subtable format 12");
+            return 0;
         }
     }
+
     class CharMapFormat6 : CharacterMap
     {
         //
@@ -114,6 +114,15 @@ namespace Typography.OpenFont
         }
 
     }
+
+    /// <summary>
+    /// An empty character map that maps all characters to glyph 0
+    /// </summary>
+    class NullCharMap : CharacterMap
+    {
+        protected override ushort RawCharacterToGlyphIndex(ushort character) { return 0; }
+    }
+
     abstract class CharacterMap
     {
         //https://www.microsoft.com/typography/otspec/cmap.htm

--- a/Typography.OpenFont/Tables.AdvancedLayout/GDEF.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GDEF.cs
@@ -116,8 +116,11 @@ namespace Typography.OpenFont.Tables
             //
             switch (MinorVersion)
             {
-                default: throw new NotSupportedException();
-                case 0: break;
+                default:
+                    Utils.WarnUnimplemented("GDEF Minor Version {0}", MinorVersion);
+                    return;
+                case 0:
+                    break;
                 case 2:
                     markGlyphSetsDefOffset = reader.ReadUInt16();
                     break;
@@ -140,8 +143,8 @@ namespace Typography.OpenFont.Tables
 
             if (itemVarStoreOffset != 0)
             {
-                //not support
-                throw new NotSupportedException();
+                //not supported
+                Utils.WarnUnimplemented("GDEF ItemVarStore");
                 reader.BaseStream.Seek(this.Header.Offset + itemVarStoreOffset, SeekOrigin.Begin);
             }
         }
@@ -181,7 +184,8 @@ namespace Typography.OpenFont.Tables
             switch (classDef.Format)
             {
                 default:
-                    throw new NotSupportedException();
+                    Utils.WarnUnimplemented("GDEF GlyphClassDef Format {0}", classDef.Format);
+                    break;
                 case 1:
                     {
                         ushort startGlyph = classDef.startGlyph;
@@ -218,7 +222,8 @@ namespace Typography.OpenFont.Tables
             AttachmentListTable attachmentListTable = this.AttachmentListTable;
             if (attachmentListTable == null) { return; }
             //-----------------------------------------
-            throw new NotSupportedException();
+
+            Utils.WarnUnimplemented("please implement GDEF.FillAttachPoints()");
         }
         void FillLigatureCarets(Glyph[] inputGlyphs)
         {
@@ -238,7 +243,8 @@ namespace Typography.OpenFont.Tables
             switch (markAttachmentClassDef.Format)
             {
                 default:
-                    throw new NotSupportedException();
+                    Utils.WarnUnimplemented("GDEF MarkAttachmentClassDef Table Format {0}", markAttachmentClassDef.Format);
+                    break;
                 case 1:
                     {
                         ushort startGlyph = markAttachmentClassDef.startGlyph;
@@ -284,10 +290,9 @@ namespace Typography.OpenFont.Tables
             //see the description of lookup flags in the “Lookup Table” section of the chapter, OpenType Layout Common Table Formats.
             MarkGlyphSetsTable markGlyphSets = this.MarkGlyphSetsTable;
             if (markGlyphSets == null) return;
-            //-------           
-            //Console.WriteLine("please implement FillMarkGlyphSets()");
+            //-----------------------------------------
 
-            throw new NotImplementedException();
+            Utils.WarnUnimplemented("please implement GDEF.FillMarkGlyphSets()");
         }
     }
 }

--- a/Typography.OpenFont/Tables/Cmap.cs
+++ b/Typography.OpenFont/Tables/Cmap.cs
@@ -91,9 +91,9 @@ namespace Typography.OpenFont.Tables
             //convert to format4 cmap table
             return new CharMapFormat4(1, new ushort[] { 0 }, new ushort[] { 255 }, null, null, only256UInt16Glyphs);
         }
+
         static CharacterMap ReadFormat_2(BinaryReader input)
         {
-
             //Format 2: High - byte mapping through table
 
             //This subtable is useful for the national character code standards used for Japanese, Chinese, and Korean characters.
@@ -136,8 +136,11 @@ namespace Typography.OpenFont.Tables
             //The value idDelta permits the same subarray to be used for several different subheaders.
             //The idDelta arithmetic is modulo 65536.
 
-            throw new System.NotImplementedException();
+            Utils.WarnUnimplemented("cmap subtable format 2");
+
+            return null;
         }
+
         static CharMapFormat4 ReadFormat_4(BinaryReader input)
         {
             ushort lenOfSubTable = input.ReadUInt16(); //This is the length in bytes of the subtable. ****
@@ -204,9 +207,10 @@ namespace Typography.OpenFont.Tables
             ushort[] glyphIdArray = Utils.ReadUInt16Array(input, entryCount);
             return new CharMapFormat6(firstCode, glyphIdArray);
         }
+
         static CharacterMap ReadFormat_12(BinaryReader input)
         {
-            //TODO: test this agina
+            //TODO: test this again
             // Format 12: Segmented coverage
             //This is the Microsoft standard character to glyph index mapping table for fonts supporting the UCS - 4 characters 
             //in the Unicode Surrogates Area(U + D800 - U + DFFF).
@@ -267,14 +271,15 @@ namespace Typography.OpenFont.Tables
             }
             return new CharMapFormat12(startCharCodes, endCharCodes, startGlyphIds);
         }
+
         static CharacterMap ReadCharacterMap(CMapEntry entry, BinaryReader input)
         {
-
             ushort format = input.ReadUInt16();
             switch (format)
             {
                 default:
-                    throw new Exception("Unknown cmap subtable: " + format); // TODO: Replace all application exceptions 
+                    Utils.WarnUnimplemented("cmap subtable format {0}", format);
+                    return new NullCharMap();
                 case 0: return ReadFormat_0(input);
                 case 2: return ReadFormat_2(input);
                 case 4: return ReadFormat_4(input);

--- a/Typography.OpenFont/Tables/Utils.cs
+++ b/Typography.OpenFont/Tables/Utils.cs
@@ -1,8 +1,10 @@
 ﻿//Apache2, 2017, WinterDev
 //Apache2, 2014-2016, Samuel Carlsson, WinterDev 
+
 using System;
 using System.Text;
 using System.IO;
+
 namespace Typography.OpenFont
 {
     static class Utils
@@ -44,6 +46,14 @@ namespace Typography.OpenFont
             Array.Copy(arr2, 0, newArr, arr1.Length, arr2.Length);
             return newArr;
         }
+
+        public static void WarnUnimplemented(string format, params object[] args)
+        {
+#if DEBUG
+            Console.WriteLine("!STUB! " + format, args);
+#endif
+        }
+
 #if DEBUG
         public static bool dbugIsDiff(GlyphPointF[] set1, GlyphPointF[] set2)
         {
@@ -65,6 +75,5 @@ namespace Typography.OpenFont
             return false;
         }
 #endif
-
     }
 }


### PR DESCRIPTION
This change allows to at least load the Segoe UI Emoji font (seguiemj.ttf)
with limited support for its features but without throwing.