### PR TITLE
Try to handle "codepoints" instead of "characters".

### DIFF
--- a/Typography.GlyphLayout/GlyphIndexList.cs
+++ b/Typography.GlyphLayout/GlyphIndexList.cs
@@ -10,7 +10,7 @@ namespace Typography.TextLayout
     class GlyphIndexList : IGlyphIndexList
     {
         List<ushort> _glyphIndices = new List<ushort>();
-        List<char> _originalChars = new List<char>();
+        List<int> _originalChars = new List<int>();
         ushort _originalOffset = 0;
         List<GlyphIndexToUserChar> _mapGlyphIndexToUserChar = new List<GlyphIndexToUserChar>();
         internal List<UserCharToGlyphIndexMap> _mapUserCharToGlyphIndics = new List<UserCharToGlyphIndexMap>();
@@ -51,7 +51,7 @@ namespace Typography.TextLayout
         /// add original char and its glyph index
         /// </summary>
         /// <param name="glyphIndex"></param>
-        public void AddGlyph(char originalChar, ushort glyphIndex)
+        public void AddGlyph(int originalChar, ushort glyphIndex)
         {
             _glyphIndices.Add(glyphIndex);
             //so we can monitor what substituion process

--- a/Typography.GlyphLayout/GlyphLayout.cs
+++ b/Typography.GlyphLayout/GlyphLayout.cs
@@ -162,8 +162,14 @@ namespace Typography.TextLayout
             for (int i = 0; i < len; ++i)
             {
                 //convert input char to input glyphs
-                char c = str[startAt + i];
-                _inputGlyphs.AddGlyph(c, (ushort)typeface.LookupIndex(c));
+                char ch = str[startAt + i];
+                int codepoint = ch;
+                if (ch >= 0xd800 && ch <= 0xdbff && i + 1 < len)
+                {
+                    ++i;
+                    codepoint = char.ConvertToUtf32(ch, str[startAt + i]);
+                }
+                _inputGlyphs.AddGlyph(codepoint, typeface.LookupIndex(codepoint));
             }
             //----------------------------------------------  
             //glyph substitution            

--- a/Typography.GlyphLayout/UserCharToGlyphIndexMap.cs
+++ b/Typography.GlyphLayout/UserCharToGlyphIndexMap.cs
@@ -11,7 +11,7 @@ namespace Typography.TextLayout
         public ushort len;
 #if DEBUG
         public ushort dbug_userCharIndex;
-        public char dbug_userChar;
+        public int dbug_userChar;
         public override string ToString()
         {
             return glyphIndexListOffset_plus1 + ":" + len;

--- a/Typography.OpenFont/CharacterMap.cs
+++ b/Typography.OpenFont/CharacterMap.cs
@@ -27,17 +27,17 @@ namespace Typography.OpenFont
             _glyphIdArray = glyphIdArray;
         }
 
-        protected override ushort RawCharacterToGlyphIndex(ushort character)
+        protected override ushort RawCharacterToGlyphIndex(int codepoint)
         {
             for (int i = 0; i < _segCount; i++)
             {
-                if (_endCode[i] >= character && _startCode[i] <= character)
+                if (_endCode[i] >= codepoint && _startCode[i] <= codepoint)
                 {
 
                     if (_idRangeOffset[i] == 0)
                     {
                         //TODO: review 65536 => use bitflags 
-                        return (ushort)((character + _idDelta[i]) % 65536);
+                        return (ushort)((codepoint + _idDelta[i]) % 65536);
                     }
                     else
                     {
@@ -52,7 +52,7 @@ namespace Typography.OpenFont
                         //+ (c - startCount[i]) 
                         //+ &idRangeOffset[i])
 
-                        var offset = _idRangeOffset[i] / 2 + (character - _startCode[i]);
+                        var offset = _idRangeOffset[i] / 2 + (codepoint - _startCode[i]);
                         // I want to thank Microsoft for this clever pointer trick
                         // TODO: What if the value fetched is inside the _idRangeOffset table?
                         // TODO: e.g. (offset - _idRangeOffset.Length + i < 0)
@@ -77,7 +77,7 @@ namespace Typography.OpenFont
             this.startGlyphIds = startGlyphIds;
 
         }
-        protected override ushort RawCharacterToGlyphIndex(ushort character)
+        protected override ushort RawCharacterToGlyphIndex(int codepoint)
         {
             throw new NotImplementedException();
         }
@@ -95,17 +95,17 @@ namespace Typography.OpenFont
             this._fmt6_end = (ushort)(startCode + glyphIdArray.Length);
             this._fmt6_start = startCode;
         }
-        protected override ushort RawCharacterToGlyphIndex(ushort character)
+        protected override ushort RawCharacterToGlyphIndex(int codepoint)
         {
             //The firstCode and entryCount values specify a subrange (beginning at firstCode, length = entryCount)
             //within the range of possible character codes.
             //Codes outside of this subrange are mapped to glyph index 0.
             //The offset of the code (from the first code) within this subrange is used as index to the glyphIdArray,
             //which provides the glyph index value. 
-            if (character >= _fmt6_start && character <= _fmt6_end)
+            if (codepoint >= _fmt6_start && codepoint <= _fmt6_end)
             {
                 //in range                            
-                return _glyphIdArray[character - _fmt6_start];
+                return _glyphIdArray[codepoint - _fmt6_start];
             }
             else
             {
@@ -122,12 +122,12 @@ namespace Typography.OpenFont
         public ushort Format { get; protected set; }
         public ushort PlatformId { get; set; }
         public ushort EncodingId { get; set; }
-        public ushort CharacterToGlyphIndex(char character)
+        public ushort CharacterToGlyphIndex(int codepoint)
         {
-            return RawCharacterToGlyphIndex(character);
+            return RawCharacterToGlyphIndex(codepoint);
         }
 
-        protected abstract ushort RawCharacterToGlyphIndex(ushort character);
+        protected abstract ushort RawCharacterToGlyphIndex(int codepoint);
 
         //public void CollectGlyphIndexListFromSampleChar(char starAt, char endAt, GlyphIndexCollector collector)
         //{

--- a/Typography.OpenFont/Tables.AdvancedLayout/GSUB.SubTables.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GSUB.SubTables.cs
@@ -13,7 +13,7 @@ namespace Typography.OpenFont.Tables
         /// add original char and its glyph index
         /// </summary>
         /// <param name="glyphIndex"></param>
-        void AddGlyph(char originalChar, ushort glyphIndex); 
+        void AddGlyph(int originalChar, ushort glyphIndex);
         int Count { get; }
         ushort this[int index] { get; }
 

--- a/Typography.OpenFont/Typeface.cs
+++ b/Typography.OpenFont/Typeface.cs
@@ -169,7 +169,7 @@ namespace Typography.OpenFont
 
         CharacterMap _selectedCmap;
 
-        public ushort LookupIndex(char character)
+        public ushort LookupIndex(int codepoint)
         {
             // TODO: What if there are none or several tables?
 
@@ -206,31 +206,34 @@ namespace Typography.OpenFont
                 }
             }
 
-            return _selectedCmap.CharacterToGlyphIndex(character);
+            return _selectedCmap.CharacterToGlyphIndex(codepoint);
         }
 
-        public Glyph Lookup(char character)
+        public Glyph Lookup(int codepoint)
         {
-            return _glyphs[LookupIndex(character)];
+            return _glyphs[LookupIndex(codepoint)];
         }
+
         public Glyph GetGlyphByIndex(int glyphIndex)
         {
             return _glyphs[glyphIndex];
         }
 
-        public ushort GetAdvanceWidth(char character)
+        public ushort GetAdvanceWidth(int codepoint)
         {
-            return _horizontalMetrics.GetAdvanceWidth(LookupIndex(character));
+            return _horizontalMetrics.GetAdvanceWidth(LookupIndex(codepoint));
         }
+
         public ushort GetHAdvanceWidthFromGlyphIndex(int glyphIndex)
         {
-
             return _horizontalMetrics.GetAdvanceWidth(glyphIndex);
         }
+
         public short GetHFrontSideBearingFromGlyphIndex(int glyphIndex)
         {
             return _horizontalMetrics.GetLeftSideBearing(glyphIndex);
         }
+
         public short GetKernDistance(ushort leftGlyphIndex, ushort rightGlyphIndex)
         {
             return _kern.GetKerningDistance(leftGlyphIndex, rightGlyphIndex);
@@ -306,10 +309,17 @@ namespace Typography.OpenFont
         {
             //do shaping here?
             //1. do look up and substitution 
-            int j = buffer.Length;
-            for (int i = 0; i < j; ++i)
+            for (int i = 0; i < buffer.Length; ++i)
             {
-                output.Add(LookupIndex(buffer[i]));
+                char ch = buffer[i];
+                int codepoint = ch;
+                if (ch >= 0xd800 && ch <= 0xdbff && i + 1 < buffer.Length)
+                {
+                    ++i;
+                    codepoint = char.ConvertToUtf32(ch, buffer[i]);
+                }
+
+                output.Add(LookupIndex(codepoint));
             }
             //tmp disable here
             //check for glyph substitution


### PR DESCRIPTION
In many places, "char" is not a valid type to handle characters, because it
only supports 16 bits. In order to handle the full range of Unicode characters,
we need to use "int".

This allows characters such as 🙌 or 𐐷 to be treated as single codepoints even
though they are encoded as two "char"s in a C# string.