### PR TITLE
Optimise glyph lookups in fonts (format 4 and format 12).

### DIFF
--- a/Typography.OpenFont/Tables/Cmap.cs
+++ b/Typography.OpenFont/Tables/Cmap.cs
@@ -89,7 +89,9 @@ namespace Typography.OpenFont.Tables
                 only256UInt16Glyphs[i] = only256Glyphs[i];
             }
             //convert to format4 cmap table
-            return new CharMapFormat4(1, new ushort[] { 0 }, new ushort[] { 255 }, null, null, only256UInt16Glyphs);
+            ushort[] array_0 = new ushort[] { 0 };
+            ushort[] array_255 = new ushort[] { 255 };
+            return new CharMapFormat4(1, array_0, array_255, array_0, array_0, only256UInt16Glyphs);
         }
 
         static CharacterMap ReadFormat_2(BinaryReader input)


### PR DESCRIPTION
Use binary search instead of sequential lookup; we now do only 11
or 12 tests per character in Segoe UI Emoji instead of 1300.

Other standard fonts typically have 100 to 200 encoded ranges,
so we only need to do 7 or 8 tests instead of 100 to 200.