### PR TITLE
Implement LookupType 7 Lookup tables.

### DIFF
--- a/Build/N20/Typography.OpenFont/Typography.OpenFont.csproj
+++ b/Build/N20/Typography.OpenFont/Typography.OpenFont.csproj
@@ -64,8 +64,14 @@
     <Compile Include="..\..\..\Typography.OpenFont\Tables.AdvancedLayout\ClassDefTable.cs">
       <Link>Tables.AdvanceLayout\ClassDefTable.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\Typography.OpenFont\Tables.AdvancedLayout\COLR.cs">
+      <Link>Tables.AdvanceLayout\COLR.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Typography.OpenFont\Tables.AdvancedLayout\CoverageTable.cs">
       <Link>Tables.AdvanceLayout\CoverageTable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\Typography.OpenFont\Tables.AdvancedLayout\CPAL.cs">
+      <Link>Tables.AdvanceLayout\CPAL.cs</Link>
     </Compile>
     <Compile Include="..\..\..\Typography.OpenFont\Tables.AdvancedLayout\FeatureInfo.cs">
       <Link>Tables.AdvanceLayout\FeatureInfo.cs</Link>

--- a/Demo/Windows/PixelFarmSample.WinForms/Form1.Designer.cs
+++ b/Demo/Windows/PixelFarmSample.WinForms/Form1.Designer.cs
@@ -101,7 +101,7 @@
             // lstFontSizes
             // 
             this.lstFontSizes.FormattingEnabled = true;
-            this.lstFontSizes.Location = new System.Drawing.Point(800, 162);
+            this.lstFontSizes.Location = new System.Drawing.Point(776, 27);
             this.lstFontSizes.Name = "lstFontSizes";
             this.lstFontSizes.Size = new System.Drawing.Size(121, 212);
             this.lstFontSizes.TabIndex = 8;
@@ -109,7 +109,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(797, 146);
+            this.label2.Location = new System.Drawing.Point(773, 9);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(70, 13);
             this.label2.TabIndex = 9;
@@ -201,7 +201,7 @@
             // 
             // cmdBuildMsdfTexture
             // 
-            this.cmdBuildMsdfTexture.Location = new System.Drawing.Point(800, 379);
+            this.cmdBuildMsdfTexture.Location = new System.Drawing.Point(776, 245);
             this.cmdBuildMsdfTexture.Name = "cmdBuildMsdfTexture";
             this.cmdBuildMsdfTexture.Size = new System.Drawing.Size(121, 37);
             this.cmdBuildMsdfTexture.TabIndex = 22;
@@ -221,9 +221,9 @@
             // lstFontList
             // 
             this.lstFontList.FormattingEnabled = true;
-            this.lstFontList.Location = new System.Drawing.Point(800, 12);
+            this.lstFontList.Location = new System.Drawing.Point(523, 146);
             this.lstFontList.Name = "lstFontList";
-            this.lstFontList.Size = new System.Drawing.Size(121, 121);
+            this.lstFontList.Size = new System.Drawing.Size(224, 316);
             this.lstFontList.TabIndex = 25;
             // 
             // chkGsubEnableLigature
@@ -241,7 +241,7 @@
             // lstHintList
             // 
             this.lstHintList.FormattingEnabled = true;
-            this.lstHintList.Location = new System.Drawing.Point(523, 71);
+            this.lstHintList.Location = new System.Drawing.Point(523, 66);
             this.lstHintList.Name = "lstHintList";
             this.lstHintList.Size = new System.Drawing.Size(224, 69);
             this.lstHintList.TabIndex = 27;

--- a/Demo/Windows/PixelFarmSample.WinForms/Form1.cs
+++ b/Demo/Windows/PixelFarmSample.WinForms/Form1.cs
@@ -274,7 +274,7 @@ namespace SampleWinForms
                         for (int i = 0; i < 3; ++i)
                         {
                             selectedTextPrinter.DrawString(printTextBuffer, x_pos, y_pos);
-                            y_pos -= lineSpacingPx;
+                            y_pos -= lineSpacingPx * 1.5f;
                         }
 
 

--- a/Typography.GlyphLayout/GlyphSubtitution.cs
+++ b/Typography.GlyphLayout/GlyphSubtitution.cs
@@ -70,9 +70,9 @@ namespace Typography.TextLayout
                     ushort[] lookupListIndices = feature.LookupListIndice;
                     foreach (ushort lookupIndex in lookupListIndices)
                     {
-                        GSUB.LookupTable lktable = gsubTable.GetLookupTable(lookupIndex);
+                        GSUB.LookupTable lktable = gsubTable.LookupList[lookupIndex];
                         lktable.ForUseWithFeatureId = feature.TagName;
-                        lookupTables.Add(gsubTable.GetLookupTable(lookupIndex));
+                        lookupTables.Add(gsubTable.LookupList[lookupIndex]);
                     }
                 }
             }

--- a/Typography.OpenFont/OpenFontReader.cs
+++ b/Typography.OpenFont/OpenFontReader.cs
@@ -101,6 +101,8 @@ namespace Typography.OpenFont
                 GSUB gsub = ReadTableIfExists(tables, input, new GSUB());
                 GPOS gpos = ReadTableIfExists(tables, input, new GPOS());
                 BASE baseTable = ReadTableIfExists(tables, input, new BASE());
+                COLR colr = ReadTableIfExists(tables, input, new COLR());
+                CPAL cpal = ReadTableIfExists(tables, input, new CPAL());
                 VerticalHeader vhea = ReadTableIfExists(tables, input, new VerticalHeader());
                 if (vhea != null)
                 {
@@ -146,7 +148,9 @@ namespace Typography.OpenFont
                     gdef,
                     gsub,
                     gpos,
-                    baseTable);
+                    baseTable,
+                    colr,
+                    cpal);
                 return typeface;
             }
         }

--- a/Typography.OpenFont/Tables.AdvancedLayout/COLR.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/COLR.cs
@@ -1,0 +1,50 @@
+﻿// Copyright © 2017 Sam Hocevar <sam@hocevar.net>
+// Apache2
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Typography.OpenFont.Tables
+{
+    public class COLR : TableEntry
+    {
+        public override string Name { get { return "COLR"; } }
+
+        // Read the COLR table
+        // https://www.microsoft.com/typography/otspec/colr.htm
+        protected override void ReadContentFrom(BinaryReader reader)
+        {
+            long offset = reader.BaseStream.Position;
+
+            ushort version = reader.ReadUInt16();
+            ushort glyphCount = reader.ReadUInt16();
+            uint glyphsOffset = reader.ReadUInt32();
+            uint layersOffset = reader.ReadUInt32();
+            ushort layersCount = reader.ReadUInt16();
+            GlyphLayers = new ushort[layersCount];
+            GlyphPalettes = new ushort[layersCount];
+
+            reader.BaseStream.Seek(offset + glyphsOffset, SeekOrigin.Begin);
+            for (int i = 0; i < glyphCount; ++i)
+            {
+                ushort gid = reader.ReadUInt16();
+                LayerIndices[gid] = reader.ReadUInt16();
+                LayerCounts[gid] = reader.ReadUInt16();
+            }
+
+            reader.BaseStream.Seek(offset + layersOffset, SeekOrigin.Begin);
+            for (int i = 0; i < GlyphLayers.Length; ++i)
+            {
+                GlyphLayers[i] = reader.ReadUInt16();
+                GlyphPalettes[i] = reader.ReadUInt16();
+            }
+        }
+
+        public ushort[] GlyphLayers { get; private set; }
+        public ushort[] GlyphPalettes { get; private set; }
+        public readonly Dictionary<ushort, ushort> LayerIndices = new Dictionary<ushort, ushort>();
+        public readonly Dictionary<ushort, ushort> LayerCounts = new Dictionary<ushort, ushort>();
+    }
+}
+

--- a/Typography.OpenFont/Tables.AdvancedLayout/CPAL.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/CPAL.cs
@@ -1,0 +1,37 @@
+﻿// Copyright © 2017 Sam Hocevar <sam@hocevar.net>
+// Apache2
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Typography.OpenFont.Tables
+{
+    public class CPAL : TableEntry
+    {
+        public override string Name { get { return "CPAL"; } }
+
+        // Read the CPAL table
+        // https://www.microsoft.com/typography/otspec/cpal.htm
+        protected override void ReadContentFrom(BinaryReader reader)
+        {
+            long offset = reader.BaseStream.Position;
+
+            ushort version = reader.ReadUInt16();
+            ushort entryCount = reader.ReadUInt16(); // XXX: unused?
+            ushort paletteCount = reader.ReadUInt16();
+            Colors = new byte[reader.ReadUInt16()][];
+            uint colorsOffset = reader.ReadUInt32();
+
+            Palettes = Utils.ReadUInt16Array(reader, paletteCount);
+
+            reader.BaseStream.Seek(offset + colorsOffset, SeekOrigin.Begin);
+            for (int i = 0; i < Colors.Length; ++i)
+                Colors[i] = reader.ReadBytes(4);
+        }
+
+        public ushort[] Palettes { get; private set; }
+        public byte[][] Colors { get; private set; }
+    }
+}
+

--- a/Typography.OpenFont/Tables.AdvancedLayout/GSUB.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GSUB.cs
@@ -37,7 +37,7 @@ namespace Typography.OpenFont.Tables
 
         ScriptList scriptList = new ScriptList();
         FeatureList featureList = new FeatureList();
-        LookupTable[] lookupTables;
+        List<LookupTable> lookupList = new List<LookupTable>();
 
         long gsubTableStartAt;
         public override string Name
@@ -104,11 +104,7 @@ namespace Typography.OpenFont.Tables
 
         public ScriptList ScriptList { get { return scriptList; } }
         public FeatureList FeatureList { get { return featureList; } }
-        public LookupTable GetLookupTable(int index)
-        {
-            return lookupTables[index];
-        }
-
+        public IList<LookupTable> LookupList { get { return lookupList; } }
 
         void ReadLookupListTable(BinaryReader reader, long lookupListHeadPos)
         {
@@ -144,18 +140,13 @@ namespace Typography.OpenFont.Tables
             //unit16 	MarkFilteringSet
             //------------------------------
             ushort lookupCount = reader.ReadUInt16();
-            lookupTables = new LookupTable[lookupCount];
-            int[] subTableOffset = new int[lookupCount];
-            for (int i = 0; i < lookupCount; ++i)
-            {
-                subTableOffset[i] = reader.ReadUInt16();
-            }
+            ushort[] lookupOffsets = Utils.ReadUInt16Array(reader, lookupCount);
             //----------------------------------------------
             //load each sub table
             //https://www.microsoft.com/typography/otspec/chapter2.htm
             for (int i = 0; i < lookupCount; ++i)
             {
-                long lookupTablePos = lookupListHeadPos + subTableOffset[i];
+                long lookupTablePos = lookupListHeadPos + lookupOffsets[i];
                 reader.BaseStream.Seek(lookupTablePos, SeekOrigin.Begin);
 
                 ushort lookupType = reader.ReadUInt16();//Each Lookup table may contain only one type of information (LookupType)
@@ -163,12 +154,33 @@ namespace Typography.OpenFont.Tables
                 ushort subTableCount = reader.ReadUInt16();
                 //Each LookupType is defined with one or more subtables, and each subtable definition provides a different representation format
                 //
-                ushort[] subTableOffsets = Utils.ReadUInt16Array(reader, subTableCount);
+                int[] subTableOffsets = new int[subTableCount];
+                for (int j = 0; j < subTableCount; ++j)
+                {
+                    subTableOffsets[j] = reader.ReadUInt16();
+                }
 
                 ushort markFilteringSet =
                     ((lookupFlags & 0x0010) == 0x0010) ? reader.ReadUInt16() : (ushort)0;
 
-                lookupTables[i] =
+                // Substitution Lookup Record
+                //
+                // When an OpenType layout engine encounters a LookupType 7 Lookup table, it shall:
+                //
+                // Proceed as though the Lookup table's LookupType field were set to the ExtensionLookupType of the subtables.
+                // Proceed as though each extension subtable referenced by ExtensionOffset replaced the LookupType 7 subtable that referenced it.
+                if (lookupType == 7)
+                {
+                    for (int j = 0; j < subTableCount; ++j)
+                    {
+                        reader.BaseStream.Seek(lookupTablePos + subTableOffsets[j], SeekOrigin.Begin);
+                        ushort version = reader.ReadUInt16(); // must be 1
+                        lookupType = reader.ReadUInt16(); // must all be the same and != 7
+                        subTableOffsets[j] += (int)reader.ReadUInt32();
+                    }
+                }
+
+                lookupList.Add(
                     new LookupTable(
                         this,
                         lookupTablePos,
@@ -176,15 +188,15 @@ namespace Typography.OpenFont.Tables
                         lookupFlags,
                         subTableCount,
                         subTableOffsets,//Array of offsets to SubTables-from beginning of Lookup table
-                        markFilteringSet);
+                        markFilteringSet));
             }
             //----------------------------------------------
             //read each lookup record content ...
             for (int i = 0; i < lookupCount; ++i)
             {
-                LookupTable lookupRecord = lookupTables[i];
+                LookupTable lookupRecord = lookupList[i];
                 //set origin
-                reader.BaseStream.Seek(lookupListHeadPos + subTableOffset[i], SeekOrigin.Begin);
+                reader.BaseStream.Seek(lookupListHeadPos + lookupOffsets[i], SeekOrigin.Begin);
                 lookupRecord.ReadRecordContent(reader);
 
                 //assign gsub owner**
@@ -212,7 +224,7 @@ namespace Typography.OpenFont.Tables
             public readonly ushort lookupType;
             public readonly ushort lookupFlags;
             public readonly ushort subTableCount;
-            public readonly ushort[] subTableOffsets;
+            public readonly int[] subTableOffsets;
             public readonly ushort markFilteringSet;
             //--------------------------
             List<LookupSubTable> subTables = new List<LookupSubTable>();
@@ -223,7 +235,7 @@ namespace Typography.OpenFont.Tables
                 ushort lookupType,
                 ushort lookupFlags,
                 ushort subTableCount,
-                ushort[] subTableOffsets,
+                int[] subTableOffsets,
                 ushort markFilteringSet
                  )
             {
@@ -245,10 +257,9 @@ namespace Typography.OpenFont.Tables
             }
             public void DoSubstitution(IGlyphIndexList inputGlyphs, int startAt, int len)
             {
-                int j = subTables.Count;
-                for (int i = 0; i < j; ++i)
+                foreach (LookupSubTable subTable in subTables)
                 {
-                    subTables[i].DoSubtitution(inputGlyphs, startAt, len);
+                    subTable.DoSubtitution(inputGlyphs, startAt, len);
                 }
             }
 #if DEBUG
@@ -285,9 +296,6 @@ namespace Typography.OpenFont.Tables
                         break;
                     case 6:
                         ReadLookupType6(reader);
-                        break;
-                    case 7:
-                        ReadLookupType7(reader);
                         break;
                     case 8:
                         ReadLookupType8(reader);
@@ -1158,7 +1166,7 @@ namespace Typography.OpenFont.Tables
 
                                         }
 #endif
-                                        LookupTable anotherLookup = this.OwnerGSub.GetLookupTable(lookupIndex);
+                                        LookupTable anotherLookup = this.OwnerGSub.LookupList[lookupIndex];
                                         anotherLookup.DoSubstitution(glyphIndices, i + replaceAt, 1);//?          
                                         //****
                                         continue;
@@ -1182,7 +1190,7 @@ namespace Typography.OpenFont.Tables
 
                                         }
 #endif
-                                        LookupTable anotherLookup = this.OwnerGSub.GetLookupTable(lookupIndex);
+                                        LookupTable anotherLookup = this.OwnerGSub.LookupList[lookupIndex];
                                         anotherLookup.DoSubstitution(glyphIndices, i + replaceAt, 1);//?                                         
                                         //****
                                         continue;
@@ -1322,62 +1330,6 @@ namespace Typography.OpenFont.Tables
                     }
                     //------------------------------------------------------------- 
                 }
-            }
-            /// <summary>
-            /// LookupType 7: Extension Substitution
-            /// </summary>
-            /// <param name="reader"></param>
-            void ReadLookupType7(BinaryReader reader)
-            {
-
-                //LookupType 7: Extension Substitution
-
-                //This lookup provides a mechanism whereby any other lookup type's subtables are stored at a 32-bit offset location in the 'GSUB' table. 
-                //This is needed if the total size of the subtables exceeds the 16-bit limits of the various other offsets in the 'GSUB' table.
-                //In this specification, the subtable stored at the 32-bit offset location is termed the “extension” subtable.
-                //----------------------------
-                //ExtensionSubstFormat1 subtable
-                //----------------------------
-                //Type      Name                Description
-                //uint16    SubstFormat         Format identifier.Set to 1.
-                //uint16    ExtensionLookupType Lookup type of subtable referenced by ExtensionOffset (i.e.the extension subtable).
-                //Offset32     ExtensionOffset     Offset to the extension subtable, of lookup type ExtensionLookupType, relative to the start of the ExtensionSubstFormat1 subtable.
-                //----------------------------
-                //ExtensionLookupType must be set to any lookup type other than 7.
-                //All subtables in a LookupType 7 lookup must have the same ExtensionLookupType.
-                //All offsets in the extension subtables are set in the usual way, 
-                //i.e.relative to the extension subtables themselves.
-
-                //When an OpenType layout engine encounters a LookupType 7 Lookup table, it shall:
-
-                //Proceed as though the Lookup table's LookupType field were set to the ExtensionLookupType of the subtables.
-                //Proceed as though each extension subtable referenced by ExtensionOffset replaced the LookupType 7 subtable that referenced it.
-
-                //Substitution Lookup Record
-
-                //All contextual substitution subtables specify the substitution data in a Substitution Lookup Record (SubstLookupRecord).
-                //Each record contains a SequenceIndex, 
-                //which indicates the position where the substitution will occur in the glyph sequence.
-                //In addition, a LookupListIndex identifies the lookup to be applied at the glyph position specified by the SequenceIndex.
-
-                //The contextual substitution subtables defined in Examples 7, 8, and 9 at the end of this chapter show SubstLookupRecords.
-                int j = subTableOffsets.Length;
-                for (int i = 0; i < j; ++i)
-                {
-                    //move to read pos
-                    long subTableStartAt = lookupTablePos + subTableOffsets[i];
-                    reader.BaseStream.Seek(subTableStartAt, SeekOrigin.Begin);
-                    ushort format = reader.ReadUInt16();
-                    ushort extensionLookupType = reader.ReadUInt16();
-                    uint extensionOffset = reader.ReadUInt32();
-                    if (extensionLookupType == 7)
-                    {
-                        throw new NotSupportedException();
-                    }
-                }
-                //TODO: impl more , this is not complete!
-                return;
-                throw new NotImplementedException();
             }
 
             /// <summary>

--- a/Typography.OpenFont/Tables/Utils.cs
+++ b/Typography.OpenFont/Tables/Utils.cs
@@ -21,15 +21,24 @@ namespace Typography.OpenFont
             Array.Reverse(bytes);
             return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
         }
-        
+
         public static ushort[] ReadUInt16Array(BinaryReader reader, int nRecords)
         {
             ushort[] arr = new ushort[nRecords];
-            int i = 0;
-            for (int n = nRecords - 1; n >= 0; --n)
+            for (int i = 0; i < nRecords; ++i)
             {
-                arr[i++] = reader.ReadUInt16();
-            } 
+                arr[i] = reader.ReadUInt16();
+            }
+            return arr;
+        }
+
+        public static uint[] ReadUInt32Array(BinaryReader reader, int nRecords)
+        {
+            uint[] arr = new uint[nRecords];
+            for (int i = 0; i < nRecords; ++i)
+            {
+                arr[i] = reader.ReadUInt32();
+            }
             return arr;
         }
 
@@ -40,6 +49,7 @@ namespace Typography.OpenFont
             Array.Copy(original, newClone, orgLen);
             return newClone;
         }
+
         public static T[] ConcatArray<T>(T[] arr1, T[] arr2)
         {
             T[] newArr = new T[arr1.Length + arr2.Length];

--- a/Typography.OpenFont/Typeface.cs
+++ b/Typography.OpenFont/Typeface.cs
@@ -267,26 +267,13 @@ namespace Typography.OpenFont
             return (targetPointSize * resolution / pointsPerInch) / this.UnitsPerEm;
         }
 
-        internal GDEF GDEFTable
-        {
-            get;
-            set;
-        }
-        public GSUB GSUBTable
-        {
-            get;
-            set;
-        }
-        public GPOS GPOSTable
-        {
-            get;
-            set;
-        }
-        internal BASE BaseTable
-        {
-            get;
-            set;
-        }
+        internal BASE BaseTable { get; set; }
+        internal GDEF GDEFTable { get; set; }
+
+        public COLR COLRTable { get; set; }
+        public CPAL CPALTable { get; set; }
+        public GPOS GPOSTable { get; set; }
+        public GSUB GSUBTable { get; set; }
 
         //-------------------------------------------------------
 
@@ -312,7 +299,7 @@ namespace Typography.OpenFont
         }
         //-------------------------------------------------------
         //experiment
-        internal void LoadOpenFontLayoutInfo(GDEF gdefTable, GSUB gsubTable, GPOS gposTable, BASE baseTable)
+        internal void LoadOpenFontLayoutInfo(GDEF gdefTable, GSUB gsubTable, GPOS gposTable, BASE baseTable, COLR colrTable, CPAL cpalTable)
         {
 
             //***
@@ -320,6 +307,8 @@ namespace Typography.OpenFont
             this.GSUBTable = gsubTable;
             this.GPOSTable = gposTable;
             this.BaseTable = baseTable;
+            this.COLRTable = colrTable;
+            this.CPALTable = cpalTable;
             //---------------------------
             //1. fill glyph definition            
             if (gdefTable != null)

--- a/Typography.OpenFont/Typography.OpenFont.projitems
+++ b/Typography.OpenFont/Typography.OpenFont.projitems
@@ -19,7 +19,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Tables.AdvancedLayout\AttachmentListTable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tables.AdvancedLayout\Base.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tables.AdvancedLayout\ClassDefTable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tables.AdvancedLayout\COLR.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tables.AdvancedLayout\CoverageTable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tables.AdvancedLayout\CPAL.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tables.AdvancedLayout\FeatureInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tables.AdvancedLayout\FeatureList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tables.AdvancedLayout\GDEF.cs" />


### PR DESCRIPTION
This feature allows to read ligatures in large fonts, and particularly
the Emoji ligatures.

This commit also adds a way for client applications to apply ligature
substitutions on an IGlyphIndexList.