### PR TITLE
Build with /unsafe in release builds, too.

### DIFF
--- a/Build/Android/Typography.GlyphLayout/Typography.GlyphLayout.csproj
+++ b/Build/Android/Typography.GlyphLayout/Typography.GlyphLayout.csproj
@@ -34,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/Build/Android/Typography.OpenFont/Typography.OpenFont/Typography.OpenFont.csproj
+++ b/Build/Android/Typography.OpenFont/Typography.OpenFont/Typography.OpenFont.csproj
@@ -34,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/Build/IOS/Typography.OpenFont/Typography.OpenFont.csproj
+++ b/Build/IOS/Typography.OpenFont/Typography.OpenFont.csproj
@@ -30,6 +30,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Build/N20/Typography.OpenFont/Typography.OpenFont.csproj
+++ b/Build/N20/Typography.OpenFont/Typography.OpenFont.csproj
@@ -29,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Build/NetCore/Typography.OpenFont/Typography.OpenFont/Typography.OpenFont.csproj
+++ b/Build/NetCore/Typography.OpenFont/Typography.OpenFont/Typography.OpenFont.csproj
@@ -8,6 +8,10 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+
   <Import Project="..\..\..\..\Typography.OpenFont\Typography.OpenFont.projitems" Label="Shared" />
 
 </Project>


### PR DESCRIPTION
I cannot build the project in Release mode without this option, using MonoDevelop or Visual Studio 2017 Community.