### PR TITLE
Fix the Linux port

### DIFF
--- a/Build/N20/Typography.GlyphLayout/Typography.GlyphLayout.csproj
+++ b/Build/N20/Typography.GlyphLayout/Typography.GlyphLayout.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Build/N20/Typography.OpenFont/Typography.OpenFont.csproj
+++ b/Build/N20/Typography.OpenFont/Typography.OpenFont.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Demo/Shared/DrawingGL.Common.shproj
+++ b/Demo/Shared/DrawingGL.Common.shproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>2e1e828f-6d2c-4b0e-a2e2-ddf24798cacf</ProjectGuid>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>

--- a/Demo/Windows/GdiPlusSample.WinForms/Form1.cs
+++ b/Demo/Windows/GdiPlusSample.WinForms/Form1.cs
@@ -52,9 +52,9 @@ namespace SampleWinForms
             installedFontCollection = new InstalledFontCollection();
             //2. set some essential handler
             installedFontCollection.SetFontNameDuplicatedHandler((f1, f2) => FontNameDuplicatedDecision.Skip);
-            installedFontCollection.LoadFontsFromFolder("..\\..\\..\\TestFonts_Err");
-            installedFontCollection.LoadFontsFromFolder("..\\..\\..\\TestFonts");
-            //installedFontCollection.LoadWindowsSystemFonts();
+            installedFontCollection.LoadFontsFromFolder(Path.Combine("..", "..", "..", "TestFonts_Err"));
+            installedFontCollection.LoadFontsFromFolder(Path.Combine("..", "..", "..", "TestFonts"));
+            //installedFontCollection.LoadSystemFonts();
 
             //---------- 
             //show result
@@ -170,7 +170,7 @@ namespace SampleWinForms
         ////msdf texture generator example
         //private void cmdBuildMsdfTexture_Click(object sender, System.EventArgs e)
         //{
-        //    string sampleFontFile = @"..\..\..\TestFonts\tahoma.ttf";
+        //    string sampleFontFile = Path.Combine("..", "..", "..", "TestFonts", "tahoma.ttf");
         //    CreateSampleMsdfTextureFont(
         //        sampleFontFile,
         //        18,

--- a/Demo/Windows/GlyphTess.WinForms/GlyphTess.WinForms.csproj
+++ b/Demo/Windows/GlyphTess.WinForms/GlyphTess.WinForms.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Demo/Windows/PixelFarmSample.WinForms/Form1.cs
+++ b/Demo/Windows/PixelFarmSample.WinForms/Form1.cs
@@ -141,13 +141,13 @@ namespace SampleWinForms
             installedFontCollection = new InstalledFontCollection();
             //2. set some essential handler
             installedFontCollection.SetFontNameDuplicatedHandler((f1, f2) => FontNameDuplicatedDecision.Skip);
-            foreach (string file in Directory.GetFiles("..\\..\\..\\TestFonts", "*.ttf"))
+            foreach (string file in Directory.GetFiles(Path.Combine("..", "..", "..", "TestFonts"), "*.ttf"))
             {
                 //eg. this is our custom font folder  
                 installedFontCollection.AddFont(new FontFileStreamProvider(file));
             }
             //3.
-            //installedFontCollection.LoadWindowsSystemFonts();
+            //installedFontCollection.LoadSystemFonts();
             //---------- 
             //show result
             InstalledFont selectedFF = null;
@@ -562,7 +562,7 @@ namespace SampleWinForms
 
             //samples...
             //1. create texture from specific glyph index range
-            string sampleFontFile = @"..\..\..\TestFonts\tahoma.ttf";
+            string sampleFontFile = Path.Combine("..", "..", "..", "TestFonts", "tahoma.ttf");
             CreateSampleMsdfTextureFont(
                 sampleFontFile,
                 18,

--- a/Demo/Windows/TextBoxSample.WinForms/Form2.cs
+++ b/Demo/Windows/TextBoxSample.WinForms/Form2.cs
@@ -62,7 +62,7 @@ namespace SampleWinForms
             installedFontCollection = new InstalledFontCollection();
             //set some essential handler
             installedFontCollection.SetFontNameDuplicatedHandler((f1, f2) => FontNameDuplicatedDecision.Skip);
-            foreach (string file in Directory.GetFiles("..\\..\\..\\TestFonts", "*.ttf"))
+            foreach (string file in Directory.GetFiles(Path.Combine("..", "..", "..", "TestFonts"), "*.ttf"))
             {
                 //eg. this is our custom font folder  
                 installedFontCollection.AddFont(new FontFileStreamProvider(file));
@@ -184,7 +184,7 @@ namespace SampleWinForms
         ////msdf texture generator example
         //private void cmdBuildMsdfTexture_Click(object sender, System.EventArgs e)
         //{
-        //    string sampleFontFile = @"..\..\..\TestFonts\tahoma.ttf";
+        //    string sampleFontFile = Path.Combine("..", "..", "..", "TestFonts", "tahoma.ttf");
         //    CreateSampleMsdfTextureFont(
         //        sampleFontFile,
         //        18,

--- a/Demo/Windows/TextBoxSample.WinForms/TextBoxSample.WinForms.csproj
+++ b/Demo/Windows/TextBoxSample.WinForms/TextBoxSample.WinForms.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/PixelFarm.Typography/1.1_Drawing_Fonts/FontManagement.cs
+++ b/PixelFarm.Typography/1.1_Drawing_Fonts/FontManagement.cs
@@ -262,7 +262,7 @@ namespace PixelFarm.Drawing.Fonts
             {
                 var reader = new OpenFontReader();
                 PreviewFontInfo previewFont = reader.ReadPreview(stream);
-                if (previewFont.fontName == "" || previewFont.fontName.StartsWith("\0"))
+                if (string.IsNullOrEmpty(previewFont.fontName))
                 {
                     //err!
                     return false;
@@ -421,33 +421,48 @@ namespace PixelFarm.Drawing.Fonts
     {
         public static void LoadFontsFromFolder(this InstalledFontCollection fontCollection, string folder)
         {
-            //1. font dir
-            foreach (string file in Directory.GetFiles(folder))
+            try
             {
-                //eg. this is our custom font folder
-                string ext = Path.GetExtension(file).ToLower();
-                switch (ext)
+                // 1. font dir
+                foreach (string file in Directory.GetFiles(folder))
                 {
-                    default: break;
-                    case ".ttf":
-                    case ".otf":
-                        fontCollection.AddFont(new FontFileStreamProvider(file));
-                        break;
+                    //eg. this is our custom font folder
+                    string ext = Path.GetExtension(file).ToLower();
+                    switch (ext)
+                    {
+                        default: break;
+                        case ".ttf":
+                        case ".otf":
+                            fontCollection.AddFont(new FontFileStreamProvider(file));
+                            break;
+                    }
                 }
 
+                //2. browse recursively; on Linux, fonts are organised in subdirectories
+                foreach (string subfolder in Directory.GetDirectories(folder))
+                {
+                    LoadFontsFromFolder(fontCollection, subfolder);
+                }
+            }
+            catch (DirectoryNotFoundException e)
+            {
+                return;
             }
         }
-        public static void LoadWindowsSystemFonts(this InstalledFontCollection fontCollection)
+        public static void LoadSystemFonts(this InstalledFontCollection fontCollection)
         {
+            // Windows system fonts
             LoadFontsFromFolder(fontCollection, "c:\\Windows\\Fonts");
-        }
-        public static void LoadMacSystemFonts(this InstalledFontCollection fontCollection)
-        {
-            //implement
-        }
-        public static void LoadLinuxSystemFonts(this InstalledFontCollection fontCollection)
-        {
-            //implement
+
+            // These are reasonable places to look for fonts on Linux
+            LoadFontsFromFolder(fontCollection, "/usr/share/fonts");
+            LoadFontsFromFolder(fontCollection, "/usr/share/wine/fonts");
+            LoadFontsFromFolder(fontCollection, "/usr/share/texlive/texmf-dist/fonts");
+            LoadFontsFromFolder(fontCollection, "/usr/share/texmf/fonts");
+
+            // OS X system fonts (https://support.apple.com/en-us/HT201722)
+            LoadFontsFromFolder(fontCollection, "/System/Library/Fonts");
+            LoadFontsFromFolder(fontCollection, "/Library/Fonts");
         }
     }
 }

--- a/PixelFarm.Typography/2_Drawing_Text/OpenFontStore.cs
+++ b/PixelFarm.Typography/2_Drawing_Text/OpenFontStore.cs
@@ -11,7 +11,7 @@ namespace PixelFarm.Drawing.Fonts
             installFontCollection = InstalledFontCollection.GetSharedFontCollection(fontCollection =>
             {
                 fontCollection.SetFontNameDuplicatedHandler((f0, f1) => FontNameDuplicatedDecision.Skip);
-                fontCollection.LoadWindowsSystemFonts();
+                fontCollection.LoadSystemFonts();
             });
 
 

--- a/PixelFarm/PixelFarm.Vectors/PixelFarm.Vectors.csproj
+++ b/PixelFarm/PixelFarm.Vectors/PixelFarm.Vectors.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Typography.GlyphLayout/Typography.GlyphLayout.shproj
+++ b/Typography.GlyphLayout/Typography.GlyphLayout.shproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>d8861cf8-c506-472b-8a57-632bd6ca6496</ProjectGuid>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>

--- a/Typography.OpenFont/Typography.OpenFont.shproj
+++ b/Typography.OpenFont/Typography.OpenFont.shproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>235a071b-8d06-40ae-a5c5-b1ce59715ee9</ProjectGuid>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>


### PR DESCRIPTION
Use tools version 14.0 instead of 15.0 in project files, as 15.0 is
not yet supported by mainstream MonoDevelop.

Replace LoadWindowsSystemFonts() with a generic LoadSystemFonts() that
queries recursively for most common font locations, and does not throw
when the directory does not exist.

Also remove a non-portable string.StartsWith("\0") construct.