### PR TITLE
GSUB: fix coverage-based glyph contexts

### DIFF
--- a/Typography.OpenFont/Tables.AdvancedLayout/CoverageTable.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/CoverageTable.cs
@@ -150,23 +150,6 @@ namespace Typography.OpenFont.Tables
 #endif
         }
 
-        //------------------------------------------------------------------------------------------
-        public static bool IsInRange(CoverageTable[] coverageTables, ushort cur_glyphIndex)
-        {
-            //just test
-            //TODO: 
-            //reduce loop by make this a dicision table*** 
-            int j = coverageTables.Length;
-            for (int i = 0; i < j; ++i)
-            {
-                int found = coverageTables[i].FindPosition(cur_glyphIndex);
-                if (found > -1)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
 #if DEBUG
         public ushort[] dbugGetExpandedGlyphs()
         {


### PR DESCRIPTION
Implement substitutions that involve both backtracking and lookahead,
and apply the proper number of substitutions (not just the first one).

Get rid of CoverageTable.IsInRange() because that method is no longer
needed and it did not do really do what it was designed for.