### PR TITLE
CoverageTable: optimisations and improvements

### DIFF
--- a/Typography.OpenFont/Tables.AdvancedLayout/CoverageTable.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/CoverageTable.cs
@@ -5,179 +5,154 @@ using System.IO;
 
 namespace Typography.OpenFont.Tables
 {
-    class CoverageTable
+    // https://www.microsoft.com/typography/otspec/chapter2.htm
+    abstract class CoverageTable
     {
-        //https://www.microsoft.com/typography/otspec/chapter2.htm
-        ushort _format;
-        ushort[] orderedGlyphIdList; //for format1
-        //----------------------------------
-        RangeRecord[] ranges;//for format2
-        //----------------------------------
+        public abstract int FindPosition(ushort glyphIndex);
 
-        public int FindPosition(ushort glyphIndex)
+#if DEBUG
+        public abstract IEnumerable<ushort> dbugGetExpandedGlyphs();
+#endif
+
+        public class CoverageFmt1 : CoverageTable
         {
-            switch (_format)
+            public static CoverageFmt1 CreateFrom(BinaryReader reader)
             {
-                //should not occur here
-                default: throw new NotSupportedException();
-                case 1:
-                    // "The glyph indices must be in numerical order for binary searching of the list"
-                    // (https://www.microsoft.com/typography/otspec/chapter2.htm#coverageFormat1)
-                    return Array.BinarySearch(orderedGlyphIdList, glyphIndex);
-                case 2:
-                    // Ranges must be in glyph ID order, and they must be distinct, with no overlapping.
-                    // [...] quick calculation of the Coverage Index for any glyph in any range using the
-                    // formula: Coverage Index (glyphID) = startCoverageIndex + glyphID - startGlyphID.
-                    // (https://www.microsoft.com/typography/otspec/chapter2.htm#coverageFormat2)
-                    {
-                        int n = Array.BinarySearch(ranges, glyphIndex);
-                        return n < 0 ? -1 : ranges[n].startCoverageIndex + glyphIndex - ranges[n].start;
-                    }
+                // CoverageFormat1 table: Individual glyph indices
+                // Type      Name                     Description
+                // uint16    CoverageFormat           Format identifier-format = 1
+                // uint16    GlyphCount               Number of glyphs in the GlyphArray
+                // uint16    GlyphArray[GlyphCount]   Array of glyph IDs — in numerical order
+
+                ushort glyphCount = reader.ReadUInt16();
+                ushort[] glyphs = Utils.ReadUInt16Array(reader, glyphCount);
+                return new CoverageFmt1() { _orderedGlyphIdList = glyphs };
             }
+
+            public override int FindPosition(ushort glyphIndex)
+            {
+                // "The glyph indices must be in numerical order for binary searching of the list"
+                // (https://www.microsoft.com/typography/otspec/chapter2.htm#coverageFormat1)
+                return Array.BinarySearch(_orderedGlyphIdList, glyphIndex);
+            }
+
+#if DEBUG
+            public override IEnumerable<ushort> dbugGetExpandedGlyphs() { return _orderedGlyphIdList; }
+
+            public override string ToString()
+            {
+                List<string> stringList = new List<string>();
+                foreach (ushort g in _orderedGlyphIdList)
+                {
+                    stringList.Add(g.ToString());
+                }
+                return "CoverageFmt1: " + string.Join(",", stringList.ToArray());
+            }
+#endif
+
+            private ushort[] _orderedGlyphIdList;
+        }
+
+        public class CoverageFmt2 : CoverageTable
+        {
+            public override int FindPosition(ushort glyphIndex)
+            {
+                // Ranges must be in glyph ID order, and they must be distinct, with no overlapping.
+                // [...] quick calculation of the Coverage Index for any glyph in any range using the
+                // formula: Coverage Index (glyphID) = startCoverageIndex + glyphID - startGlyphID.
+                // (https://www.microsoft.com/typography/otspec/chapter2.htm#coverageFormat2)
+                int n = Array.BinarySearch(_endIndices, glyphIndex);
+                n = n < 0 ? ~n : n;
+                if (n >= RangeCount || glyphIndex < _startIndices[n])
+                {
+                    return -1;
+                }
+                return _coverageIndices[n] + glyphIndex - _startIndices[n];
+            }
+
+            public static CoverageFmt2 CreateFrom(BinaryReader reader)
+            {
+                // CoverageFormat2 table: Range of glyphs
+                // Type      Name                     Description
+                // uint16    CoverageFormat           Format identifier-format = 2
+                // uint16    RangeCount               Number of RangeRecords
+                // struct    RangeRecord[RangeCount]  Array of glyph ranges — ordered by StartGlyphID.
+                //
+                // RangeRecord
+                // Type      Name                Description
+                // uint16    StartGlyphID        First glyph ID in the range
+                // uint16    EndGlyphID          Last glyph ID in the range
+                // uint16    StartCoverageIndex  Coverage Index of first glyph ID in range
+
+                ushort rangeCount = reader.ReadUInt16();
+                ushort[] startIndices = new ushort[rangeCount];
+                ushort[] endIndices = new ushort[rangeCount];
+                ushort[] coverageIndices = new ushort[rangeCount];
+                for (int i = 0; i < rangeCount; ++i)
+                {
+                    startIndices[i] = reader.ReadUInt16();
+                    endIndices[i] = reader.ReadUInt16();
+                    coverageIndices[i] = reader.ReadUInt16();
+                }
+
+                return new CoverageFmt2()
+                {
+                    _startIndices = startIndices,
+                    _endIndices = endIndices,
+                    _coverageIndices = coverageIndices
+                };
+            }
+
+#if DEBUG
+            public override IEnumerable<ushort> dbugGetExpandedGlyphs()
+            {
+                for (int i = 0; i < RangeCount; ++i)
+                {
+                    for (ushort n = _startIndices[i]; n <= _endIndices[i]; ++n)
+                    {
+                        yield return n;
+                    }
+                }
+            }
+
+            public override string ToString()
+            {
+                List<string> stringList = new List<string>();
+                for (int i = 0; i < RangeCount; ++i)
+                {
+                    stringList.Add(string.Format("{0}-{1}", _startIndices[i], _endIndices[i]));
+                }
+                return "CoverageFmt2: " + string.Join(",", stringList.ToArray());
+            }
+#endif
+
+            private ushort[] _startIndices;
+            private ushort[] _endIndices;
+            private ushort[] _coverageIndices;
+
+            private int RangeCount { get { return _startIndices.Length; } }
         }
 
         public static CoverageTable CreateFrom(BinaryReader reader, long beginAt)
         {
             reader.BaseStream.Seek(beginAt, SeekOrigin.Begin);
-            //---------------------------------------------------
-            var coverageTable = new CoverageTable();
-
-            //CoverageFormat1 table: Individual glyph indices
-            //Type      Name                       Description
-            //uint16    CoverageFormat             Format identifier-format = 1
-            //uint16    GlyphCount  	           Number of glyphs in the GlyphArray
-            //uint16    GlyphArray[GlyphCount] 	   Array of glyph IDs — in numerical order
-            //---------------------------------
-            //CoverageFormat2 table: Range of glyphs 
-            //Type      Name                       Description           
-            //uint16    CoverageFormat             Format identifier-format = 2
-            //uint16    RangeCount                 Number of RangeRecords
-            //struct    RangeRecord[RangeCount]    Array of glyph ranges — ordered by StartGlyphID.
-            //------------
-            //RangeRecord
-            //----------
-            //Type      Name                Description
-            //uint16    StartGlyphID        First glyph ID in the range
-            //uint16    EndGlyphID          Last glyph ID in the range
-            //uint16    StartCoverageIndex  Coverage Index of first glyph ID in range
-            //----------
-
-            switch (coverageTable._format = reader.ReadUInt16())
+            ushort format = reader.ReadUInt16();
+            switch (format)
             {
-                default:
-                    throw new NotSupportedException();
-                case 1:    //CoverageFormat1 table: Individual glyph indices
-                    {
-                        ushort glyphCount = reader.ReadUInt16();
-                        coverageTable.orderedGlyphIdList = Utils.ReadUInt16Array(reader, glyphCount);
-                    }
-                    break;
-                case 2:  //CoverageFormat2 table: Range of glyphs
-                    {
-
-                        ushort rangeCount = reader.ReadUInt16();
-                        RangeRecord[] ranges = new RangeRecord[rangeCount];
-                        for (int i = 0; i < rangeCount; ++i)
-                        {
-                            ranges[i] = new RangeRecord(
-                                reader.ReadUInt16(),
-                                reader.ReadUInt16(),
-                                reader.ReadUInt16());
-                        }
-                        coverageTable.ranges = ranges;
-                    }
-                    break;
-
+                default: throw new NotSupportedException();
+                case 1: return CoverageFmt1.CreateFrom(reader);
+                case 2: return CoverageFmt2.CreateFrom(reader);
             }
-            return coverageTable;
         }
 
         public static CoverageTable[] CreateMultipleCoverageTables(long initPos, ushort[] offsets, BinaryReader reader)
         {
-            int j = offsets.Length;
-            CoverageTable[] results = new CoverageTable[j];
-            for (int i = 0; i < j; ++i)
+            List<CoverageTable> results = new List<CoverageTable>();
+            foreach (ushort offset in offsets)
             {
-                results[i] = CoverageTable.CreateFrom(reader, initPos + offsets[i]);
+                results.Add(CoverageTable.CreateFrom(reader, initPos + offset));
             }
-            return results;
+            return results.ToArray();
         }
-
-        struct RangeRecord : IComparable
-        {
-            //------------
-            //RangeRecord
-            //----------
-            //Type      Name                Description
-            //uint16    StartGlyphID        First glyph ID in the range
-            //uint16    EndGlyphID          Last glyph ID in the range
-            //uint16    StartCoverageIndex  Coverage Index of first glyph ID in range
-            //----------
-            public readonly ushort start;
-            public readonly ushort end;
-            public readonly ushort startCoverageIndex;
-            public RangeRecord(ushort start, ushort end, ushort startCoverageIndex)
-            {
-                this.start = start;
-                this.end = end;
-                this.startCoverageIndex = startCoverageIndex;
-            }
-            public bool Contains(ushort glyphIndex)
-            {
-                return glyphIndex >= start && glyphIndex <= end;
-            }
-            public int FindPosition(ushort glyphIndex)
-            {
-                return Contains(glyphIndex) ? glyphIndex - start : -1;
-            }
-
-            // This special comparator allows for binary searching inside all the ranges.
-            public int CompareTo(object obj)
-            {
-                if (obj is ushort)
-                {
-                    ushort n = (ushort)obj;
-                    return n < start ? 1 : n > end ? -1 : 0;
-                }
-                throw new NotImplementedException();
-            }
-
-#if DEBUG
-            public override string ToString()
-            {
-                return "range: index, " + startCoverageIndex + "[" + start + "," + end + "]";
-            }
-#endif
-        }
-
-#if DEBUG
-        public ushort[] dbugGetExpandedGlyphs()
-        {
-            switch (_format)
-            {
-                default:
-                    throw new NotSupportedException();
-                case 1:
-                    return orderedGlyphIdList;
-                case 2:
-                    {
-                        List<ushort> list = new List<ushort>();
-                        int j = ranges.Length;
-                        for (int i = 0; i < j; ++i)
-                        {
-                            RangeRecord range = ranges[i];
-                            for (ushort n = range.start; n <= range.end; ++n)
-                            {
-                                list.Add(n);
-                            }
-                        }
-                        return list.ToArray();
-                    }
-
-            }
-
-        }
-#endif
     }
-
 }

--- a/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
@@ -437,14 +437,14 @@ namespace Typography.OpenFont.Tables
                 public void dbugTest()
                 {
                     //count base covate
-                    ushort[] expandedMarks = MarkCoverageTable.dbugGetExpandedGlyphs();
-                    if (expandedMarks.Length != MarkArrayTable.dbugGetAnchorCount())
+                    List<ushort> expandedMarks = new List<ushort>(MarkCoverageTable.dbugGetExpandedGlyphs());
+                    if (expandedMarks.Count != MarkArrayTable.dbugGetAnchorCount())
                     {
                         throw new NotSupportedException();
                     }
                     //--------------------------
-                    ushort[] expandedBase = BaseCoverageTable.dbugGetExpandedGlyphs();
-                    if (expandedBase.Length != BaseArrayTable.dbugGetRecordCount())
+                    List<ushort> expandedBase = new List<ushort>(BaseCoverageTable.dbugGetExpandedGlyphs());
+                    if (expandedBase.Count != BaseArrayTable.dbugGetRecordCount())
                     {
                         throw new NotSupportedException();
                     }


### PR DESCRIPTION
Make formats 1 and 2 two different classes to avoid the need for a switch
in FindPosition(). Get rid of the RangeRecord class because it is a lot
faster to perform a binary search inside integer arrays.

Also make the debug functions a bit nicer.