### PR TITLE
Feature: cmap format 14

### DIFF
--- a/Typography.OpenFont/CharacterMap.cs
+++ b/Typography.OpenFont/CharacterMap.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Typography.OpenFont
 {
@@ -128,6 +129,164 @@ namespace Typography.OpenFont
 
         private readonly ushort _startCode;
         private readonly ushort[] _glyphIdArray;
+    }
+
+    // Subtable format 14 specifies the Unicode Variation Sequences(UVSes) supported by the font.
+    // A Variation Sequence, according to the Unicode Standard, comprises a base character followed
+    // by a variation selector; e.g. <U+82A6, U+E0101>.
+    //
+    // The subtable partitions the UVSes supported by the font into two categories: “default” and
+    // “non-default” UVSes.Given a UVS, if the glyph obtained by looking up the base character of
+    // that sequence in the Unicode cmap subtable(i.e.the UCS-4 or the BMP cmap subtable) is the
+    // glyph to use for that sequence, then the sequence is a “default” UVS; otherwise it is a
+    // “non-default” UVS, and the glyph to use for that sequence is specified in the format 14
+    // subtable itself.
+    class CharMapFormat14 : NullCharMap
+    {
+        public override ushort Format { get { return 14; } }
+
+        public static CharMapFormat14 Create(BinaryReader reader)
+        {
+            // 'cmap' Subtable Format 14:
+            // Type       Name        Description
+            // uint16     format      Subtable format.Set to 14.
+            // uint32     length      Byte length of this subtable (including this header)
+            // uint32     numVarSelectorRecords
+            //                        Number of variation Selector Records
+            // VariationSelector   varSelector[numVarSelectorRecords]
+            //                        Array of VariationSelector records.
+            //
+            // Each variation selector records specifies a variation selector character, and
+            // offsets to “default” and “non-default” tables used to map variation sequences using
+            // that variation selector.
+            //
+            // VariationSelector Record:
+            // Type      Name                 Description
+            // uint24    varSelector          Variation selector
+            // Offset32  defaultUVSOffset     Offset from the start of the format 14 subtable to
+            //                                Default UVS Table.May be 0.
+            // Offset32  nonDefaultUVSOffset  Offset from the start of the format 14 subtable to
+            //                                Non-Default UVS Table. May be 0.
+            //
+            // The Variation Selector Records are sorted in increasing order of ‘varSelector’. No
+            // two records may have the same ‘varSelector’.
+            // A Variation Selector Record and the data its offsets point to specify those UVSes
+            // supported by the font for which the variation selector is the ‘varSelector’ value
+            // of the record. The base characters of the UVSes are stored in the tables pointed
+            // to by the offsets.The UVSes are partitioned by whether they are default or
+            // non-default UVSes.
+            // Glyph IDs to be used for non-default UVSes are specified in the Non-Default UVS table.
+
+            long beginAt = reader.BaseStream.Position - 2; // account for header format entry
+
+            var variationSelectors = new Dictionary<uint, VariationSelector>();
+
+            uint length = reader.ReadUInt32(); // Byte length of this subtable (including the header)
+            uint numVarSelectorRecords = reader.ReadUInt32();
+            uint[] varSelectors = new uint[numVarSelectorRecords];
+            uint[] defaultUVSOffsets = new uint[numVarSelectorRecords];
+            uint[] nonDefaultUVSOffsets = new uint[numVarSelectorRecords];
+            for (int i = 0; i < numVarSelectorRecords; ++i)
+            {
+                varSelectors[i] = Utils.ReadUInt24(reader);
+                defaultUVSOffsets[i] = reader.ReadUInt32();
+                nonDefaultUVSOffsets[i] = reader.ReadUInt32();
+            }
+
+            for (int i = 0; i < numVarSelectorRecords; ++i)
+            {
+                var sel = new VariationSelector();
+
+                if (defaultUVSOffsets[i] != 0)
+                {
+                    // Default UVS table
+                    //
+                    // A Default UVS Table is simply a range-compressed list of Unicode scalar
+                    // values, representing the base characters of the default UVSes which use
+                    // the ‘varSelector’ of the associated Variation Selector Record.
+                    //
+                    // DefaultUVS Table:
+                    // Type          Name                           Description
+                    // uint32        numUnicodeValueRanges          Number of Unicode character ranges.
+                    // UnicodeRange  ranges[numUnicodeValueRanges]  Array of UnicodeRange records.
+                    //
+                    // Each Unicode range record specifies a contiguous range of Unicode values.
+                    //
+                    // UnicodeRange Record:
+                    // Type    Name               Description
+                    // uint24  startUnicodeValue  First value in this range
+                    // uint8   additionalCount    Number of additional values in this range
+                    //
+                    // For example, the range U+4E4D&endash; U+4E4F (3 values) will set
+                    // ‘startUnicodeValue’ to 0x004E4D and ‘additionalCount’ to 2. A singleton
+                    // range will set ‘additionalCount’ to 0.
+                    // (‘startUnicodeValue’ + ‘additionalCount’) must not exceed 0xFFFFFF.
+                    // The Unicode Value Ranges are sorted in increasing order of
+                    // ‘startUnicodeValue’. The ranges must not overlap; i.e.,
+                    // (‘startUnicodeValue’ + ‘additionalCount’) must be less than the
+                    // ‘startUnicodeValue’ of the following range (if any).
+
+                    reader.BaseStream.Seek(beginAt + defaultUVSOffsets[i], SeekOrigin.Begin);
+                    uint numUnicodeValueRanges = reader.ReadUInt32();
+                    for (int n = 0; n < numUnicodeValueRanges; ++n)
+                    {
+                        uint startCode = Utils.ReadUInt24(reader);
+                        sel.DefaultStartCodes.Add(startCode);
+                        sel.DefaultEndCodes.Add(startCode + reader.ReadByte());
+                    }
+                }
+
+                if (nonDefaultUVSOffsets[i] != 0)
+                {
+                    // Non-Default UVS table
+                    //
+                    // A Non-Default UVS Table is a list of pairs of Unicode scalar values and
+                    // glyph IDs.The Unicode values represent the base characters of all
+                    // non -default UVSes which use the ‘varSelector’ of the associated Variation
+                    // Selector Record, and the glyph IDs specify the glyph IDs to use for the
+                    // UVSes.
+                    //
+                    // NonDefaultUVS Table:
+                    // Type        Name                         Description
+                    // uint32      numUVSMappings               Number of UVS Mappings that follow
+                    // UVSMapping  uvsMappings[numUVSMappings]  Array of UVSMapping records.
+                    //
+                    // Each UVSMapping record provides a glyph ID mapping for one base Unicode
+                    // character, when that base character is used in a variation sequence with
+                    // the current variation selector.
+                    //
+                    // UVSMapping Record:
+                    // Type    Name          Description
+                    // uint24  unicodeValue  Base Unicode value of the UVS
+                    // uint16  glyphID       Glyph ID of the UVS
+                    //
+                    // The UVS Mappings are sorted in increasing order of ‘unicodeValue’. No two
+                    // mappings in this table may have the same ‘unicodeValue’ values.
+
+                    reader.BaseStream.Seek(beginAt + nonDefaultUVSOffsets[i], SeekOrigin.Begin);
+                    uint numUVSMappings = reader.ReadUInt32();
+                    for (int n = 0; n < numUVSMappings; ++n)
+                    {
+                        uint unicodeValue = Utils.ReadUInt24(reader);
+                        ushort glyphID = reader.ReadUInt16();
+                        sel.UVSMappings.Add(unicodeValue, glyphID);
+                    }
+                }
+
+                variationSelectors.Add(varSelectors[i], sel);
+            }
+
+            return new CharMapFormat14 { _variationSelectors = variationSelectors };
+        }
+
+        private class VariationSelector
+        {
+            public List<uint> DefaultStartCodes = new List<uint>();
+            public List<uint> DefaultEndCodes = new List<uint>();
+            public Dictionary<uint, ushort> UVSMappings = new Dictionary<uint, ushort>();
+        }
+
+        private Dictionary<uint, VariationSelector> _variationSelectors;
     }
 
     /// <summary>

--- a/Typography.OpenFont/OpenFontReader.cs
+++ b/Typography.OpenFont/OpenFontReader.cs
@@ -119,10 +119,10 @@ namespace Typography.OpenFont
                     header.Bounds,
                     header.UnitsPerEm,
                     glyf.Glyphs,
-                    cmaps.CharMaps,
                     horizontalMetrics,
                     os2Table);
                 //----------------------------
+                typeface.CmapTable = cmaps;
                 typeface.KernTable = kern;
                 typeface.GaspTable = gaspTable;
                 typeface.MaxProfile = maximumProfile;

--- a/Typography.OpenFont/Tables/Cmap.cs
+++ b/Typography.OpenFont/Tables/Cmap.cs
@@ -141,8 +141,7 @@ namespace Typography.OpenFont.Tables
             //The idDelta arithmetic is modulo 65536.
 
             Utils.WarnUnimplemented("cmap subtable format 2");
-
-            return null;
+            return new NullCharMap();
         }
 
         static CharMapFormat4 ReadFormat_4(BinaryReader input)
@@ -289,6 +288,7 @@ namespace Typography.OpenFont.Tables
                 case 4: return ReadFormat_4(input);
                 case 6: return ReadFormat_6(input);
                 case 12: return ReadFormat_12(input);
+                case 14: return CharMapFormat14.Create(input);
             }
         }
 

--- a/Typography.OpenFont/Tables/Cmap.cs
+++ b/Typography.OpenFont/Tables/Cmap.cs
@@ -31,7 +31,7 @@ namespace Typography.OpenFont.Tables
     {
         public override string Name { get { return "cmap"; } }
 
-        public ushort LookupIndex(int codepoint)
+        public ushort LookupIndex(int codepoint, int nextCodepoint = 0)
         {
             // https://www.microsoft.com/typography/OTSPEC/cmap.htm
             // "character codes that do not correspond to any glyph in the font should be mapped to glyph index 0."
@@ -52,6 +52,27 @@ namespace Typography.OpenFont.Tables
                 }
 
                 _codepointToGlyphs[codepoint] = ret;
+            }
+
+            // If there is a second codepoint, we are asked whether this is an UVS sequence
+            //  -> if true, return a glyph ID
+            //  -> otherwise, return 0
+            if (nextCodepoint > 0)
+            {
+                foreach (CharacterMap cmap in _charMaps)
+                {
+                    if (cmap is CharMapFormat14)
+                    {
+                        CharMapFormat14 cmap14 = cmap as CharMapFormat14;
+                        ushort gid = cmap14.CharacterPairToGlyphIndex(codepoint, ret, nextCodepoint);
+                        if (gid > 0)
+                        {
+                            return gid;
+                        }
+                    }
+                }
+
+                return 0;
             }
 
             return ret;

--- a/Typography.OpenFont/Tables/Utils.cs
+++ b/Typography.OpenFont/Tables/Utils.cs
@@ -22,6 +22,12 @@ namespace Typography.OpenFont
             return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
         }
 
+        public static uint ReadUInt24(BinaryReader reader)
+        {
+            uint highByte = reader.ReadByte();
+            return (highByte << 16) | reader.ReadUInt16();
+        }
+
         public static ushort[] ReadUInt16Array(BinaryReader reader, int nRecords)
         {
             ushort[] arr = new ushort[nRecords];

--- a/Typography.OpenFont/Typeface.cs
+++ b/Typography.OpenFont/Typeface.cs
@@ -164,9 +164,9 @@ namespace Typography.OpenFont
             get { return _nameEntry.FontSubFamily; }
         }
 
-        public ushort LookupIndex(int codepoint)
+        public ushort LookupIndex(int codepoint, int nextCodepoint = 0)
         {
-            return CmapTable.LookupIndex(codepoint);
+            return CmapTable.LookupIndex(codepoint, nextCodepoint);
         }
 
         public Glyph Lookup(int codepoint)

--- a/Typography.OpenFont/Typeface.cs
+++ b/Typography.OpenFont/Typeface.cs
@@ -10,7 +10,6 @@ namespace Typography.OpenFont
         readonly Bounds _bounds;
         readonly ushort _unitsPerEm;
         readonly Glyph[] _glyphs;
-        readonly CharacterMap[] _cmaps;
         //TODO: implement vertical metrics
         readonly HorizontalMetrics _horizontalMetrics;
         readonly NameEntry _nameEntry;
@@ -22,7 +21,6 @@ namespace Typography.OpenFont
             Bounds bounds,
             ushort unitsPerEm,
             Glyph[] glyphs,
-            CharacterMap[] cmaps,
             HorizontalMetrics horizontalMetrics,
             OS2Table os2Table)
         {
@@ -30,7 +28,6 @@ namespace Typography.OpenFont
             _bounds = bounds;
             _unitsPerEm = unitsPerEm;
             _glyphs = glyphs;
-            _cmaps = cmaps;
             _horizontalMetrics = horizontalMetrics;
             OS2Table = os2Table;
 
@@ -67,6 +64,7 @@ namespace Typography.OpenFont
         internal MaxProfile MaxProfile { get; set; }
 
         public bool HasPrepProgramBuffer { get { return PrepProgramBuffer != null; } }
+        internal Cmap CmapTable { get; set; }
         internal Kern KernTable
         {
             get { return _kern; }
@@ -166,34 +164,9 @@ namespace Typography.OpenFont
             get { return _nameEntry.FontSubFamily; }
         }
 
-
-       
-        private Dictionary<int, ushort> _codepointToGlyphs = new Dictionary<int, ushort>();
-
         public ushort LookupIndex(int codepoint)
         {
-            // https://www.microsoft.com/typography/OTSPEC/cmap.htm
-            // "character codes that do not correspond to any glyph in the font should be mapped to glyph index 0."
-            ushort ret = 0;
-
-            if (!_codepointToGlyphs.TryGetValue(codepoint, out ret))
-            {
-                foreach (CharacterMap cmap in _cmaps)
-                {
-                    ushort gid = cmap.CharacterToGlyphIndex(codepoint);
-
-                    //https://www.microsoft.com/typography/OTSPEC/cmap.htm
-                    //...When building a Unicode font for Windows, the platform ID should be 3 and the encoding ID should be 1
-                    if (ret == 0 || (gid != 0 && cmap.PlatformId == 3 && cmap.EncodingId == 1))
-                    {
-                        ret = gid;
-                    }
-                }
-
-                _codepointToGlyphs[codepoint] = ret;
-            }
-
-            return ret;
+            return CmapTable.LookupIndex(codepoint);
         }
 
         public Glyph Lookup(int codepoint)


### PR DESCRIPTION
I am not really happy with this code, please consider it a proof of concept for now. The idea behind Cmap format 14 is that glyph resolution can be modified by the following Unicode character (see [Unicode Variant Forms](https://en.wikipedia.org/wiki/Variant_form_(Unicode))). It is a bit like ligatures, but must operate *before* GSUB substitution.

Example with the emoji 👩🏿‍⚕️ “Woman Health Worker: Dark Skin Tone”:

   * Unicode sequence: `U+1f469 U+1f3ff U+200d U+2695 U+fe0f`
   * Character to glyph (without cmap 14): `1125 1088 390 9649 665`
   * Character to glyph (with cmap 14): `1125 1088 390 9649`
   * After first ligature: `1136 390 9649`
   * After second ligature: `8717`

Before, the sequence would give two glyphs, `8717 665`, and was incorrectly rendered.