### PR TITLE
Fix two bugs in GenerateGlyphPlan().

### DIFF
--- a/Typography.GlyphLayout/GlyphLayout.cs
+++ b/Typography.GlyphLayout/GlyphLayout.cs
@@ -380,7 +380,7 @@ namespace Typography.TextLayout
                     //if you want to snap each glyph to grid (1px or 0.5px) by ROUNDING
                     //we can do it here,this produces a predictable caret position result
                     //
-                    s_advW += (int)Math.Round(s_advW);
+                    s_advW = (int)Math.Round(s_advW);
                 }
                 float exact_x = (float)(cx + offsetX * pxscale);
                 float exact_y = (float)(cy + offsetY * pxscale);
@@ -389,7 +389,7 @@ namespace Typography.TextLayout
                    glyphIndex,
                     exact_x,
                     exact_y,
-                    advW));
+                    advW * pxscale));
                 cx += s_advW;
 
             }


### PR DESCRIPTION
Advance width was incorrectly calculated in snap to grid mode, and pixel scale
was applied to the glyph coordinates value but not the glyph advance.