### PR TITLE
Standardise all glyph indexes to use ushort

### DIFF
--- a/PixelFarm.Typography/3_FontFaceImpl/NOpenFontFace.cs
+++ b/PixelFarm.Typography/3_FontFaceImpl/NOpenFontFace.cs
@@ -162,14 +162,14 @@ namespace PixelFarm.Drawing.Fonts
 
         public override FontGlyph GetGlyph(char c)
         {
-            return GetGlyphByIndex((uint)typeFace.LookupIndex(c));
+            return GetGlyphByIndex(typeFace.LookupIndex(c));
         }
-        public override FontGlyph GetGlyphByIndex(uint glyphIndex)
+        public override FontGlyph GetGlyphByIndex(ushort glyphIndex)
         {
             //1.  
             FontGlyph fontGlyph = new FontGlyph();
             fontGlyph.flattenVxs = GetGlyphVxs(glyphIndex);
-            fontGlyph.horiz_adv_x = typeFace.GetHAdvanceWidthFromGlyphIndex((int)glyphIndex);
+            fontGlyph.horiz_adv_x = typeFace.GetHAdvanceWidthFromGlyphIndex(glyphIndex);
 
             return fontGlyph;
         }

--- a/PixelFarm/PixelFarm.DrawingCanvas/3_Drawing_Fonts/ActualFont.cs
+++ b/PixelFarm/PixelFarm.DrawingCanvas/3_Drawing_Fonts/ActualFont.cs
@@ -26,7 +26,7 @@ namespace PixelFarm.Drawing.Fonts
 #endif
         protected abstract void OnDispose();
         //---------------------
-        public abstract FontGlyph GetGlyphByIndex(uint glyphIndex);
+        public abstract FontGlyph GetGlyphByIndex(ushort glyphIndex);
         public abstract FontGlyph GetGlyph(char c);
         public abstract FontFace FontFace { get; }
         public abstract FontStyle FontStyle { get; }

--- a/Typography.OpenFont/Tables.TrueType/Glyf.cs
+++ b/Typography.OpenFont/Tables.TrueType/Glyf.cs
@@ -32,7 +32,7 @@ namespace Typography.OpenFont.Tables
             int glyphCount = locations.GlyphCount;
             _glyphs = new Glyph[glyphCount];
 
-            List<int> compositeGlyphs = new List<int>();
+            List<ushort> compositeGlyphs = new List<ushort>();
 
             for (int i = 0; i < glyphCount; i++)
             {
@@ -58,7 +58,7 @@ namespace Typography.OpenFont.Tables
                     {
                         //skip composite glyph,
                         //resolve later
-                        compositeGlyphs.Add(i);
+                        compositeGlyphs.Add((ushort)i);
                     }
                 }
                 else
@@ -70,7 +70,7 @@ namespace Typography.OpenFont.Tables
             //--------------------------------
             //resolve composte glyphs 
             //--------------------------------
-            foreach (int glyphIndex in compositeGlyphs)
+            foreach (ushort glyphIndex in compositeGlyphs)
             {
 #if DEBUG
                 if (glyphIndex == 7)
@@ -252,7 +252,7 @@ namespace Typography.OpenFont.Tables
             UNSCALED_COMPONENT_OFFSET = 1 << 12
         }
 
-        Glyph ReadCompositeGlyph(Glyph[] createdGlyphs, BinaryReader reader, uint tableOffset, int compositeGlyphIndex)
+        Glyph ReadCompositeGlyph(Glyph[] createdGlyphs, BinaryReader reader, uint tableOffset, ushort compositeGlyphIndex)
         {
             //------------------------------------------------------ 
             //https://www.microsoft.com/typography/OTSPEC/glyf.htm
@@ -382,7 +382,7 @@ namespace Typography.OpenFont.Tables
                     {
                         //use this matrix  
                         Glyph.TransformNormalWith2x2Matrix(newGlyph, xscale, scale01, scale10, yscale);
-                        Glyph.OffsetXY(newGlyph, (short)(arg1), arg2);
+                        Glyph.OffsetXY(newGlyph, arg1, arg2);
                     }
                     else
                     {

--- a/Typography.OpenFont/Typeface.cs
+++ b/Typography.OpenFont/Typeface.cs
@@ -182,7 +182,7 @@ namespace Typography.OpenFont
         {
             return _glyphs[LookupIndex(codepoint)];
         }
-        public Glyph GetGlyphByIndex(int glyphIndex)
+        public Glyph GetGlyphByIndex(ushort glyphIndex)
         {
             return _glyphs[glyphIndex];
         }
@@ -234,12 +234,12 @@ namespace Typography.OpenFont
         {
             return _horizontalMetrics.GetAdvanceWidth(LookupIndex(codepoint));
         }
-        public ushort GetHAdvanceWidthFromGlyphIndex(int glyphIndex)
+        public ushort GetHAdvanceWidthFromGlyphIndex(ushort glyphIndex)
         {
 
             return _horizontalMetrics.GetAdvanceWidth(glyphIndex);
         }
-        public short GetHFrontSideBearingFromGlyphIndex(int glyphIndex)
+        public short GetHFrontSideBearingFromGlyphIndex(ushort glyphIndex)
         {
             return _horizontalMetrics.GetLeftSideBearing(glyphIndex);
         }


### PR DESCRIPTION
I cannot bear the use of ints and uints in place of ushorts