### PR TITLE
Change .NET Standard projects to use .NET Standard 1.3

### DIFF
--- a/Build/NetStandard/FontAtlas/FontAtlas.csproj
+++ b/Build/NetStandard/FontAtlas/FontAtlas.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Build/NetStandard/Typography.Contours/Typography.Contours.csproj
+++ b/Build/NetStandard/Typography.Contours/Typography.Contours.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Build/NetStandard/Typography.GlyphLayout/Typography.GlyphLayout.csproj
+++ b/Build/NetStandard/Typography.GlyphLayout/Typography.GlyphLayout.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Build/NetStandard/Typography.MsdfGen/Typography.MsdfGen.csproj
+++ b/Build/NetStandard/Typography.MsdfGen/Typography.MsdfGen.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard1.0</TargetFramework>
   </PropertyGroup>
 
   <Import Project="..\..\..\Typography.MsdfGen\Typography.MsdfGen.projitems" Label="Shared" />

--- a/Build/NetStandard/Typography.OpenFont/Typography.OpenFont.csproj
+++ b/Build/NetStandard/Typography.OpenFont/Typography.OpenFont.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Build/NetStandard/Typography.TextBreak/Typography.TextBreak.csproj
+++ b/Build/NetStandard/Typography.TextBreak/Typography.TextBreak.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
  
 

--- a/Build/NetStandard/Typography.TextFlow/Typography.TextFlow.csproj
+++ b/Build/NetStandard/Typography.TextFlow/Typography.TextFlow.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Build/NetStandard/Typography.TextServices/Typography.TextServices.csproj
+++ b/Build/NetStandard/Typography.TextServices/Typography.TextServices.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
 
   <Import Project="..\..\..\Typography.TextServices\Typography.TextServices.projitems" Label="Shared" />

--- a/Demo/iOS/Xamarin.iOS.GLES2/Xamarin.IOS.GLES2.csproj
+++ b/Demo/iOS/Xamarin.iOS.GLES2/Xamarin.IOS.GLES2.csproj
@@ -118,6 +118,7 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO" />
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>

--- a/Typography.OpenFont/Tables.CFF/CFF.cs
+++ b/Typography.OpenFont/Tables.CFF/CFF.cs
@@ -656,7 +656,7 @@ namespace Typography.OpenFont.CFF
                 CffIndexOffset indexElem = nameIndexElems[i];
                 //TODO: review here again, 
                 //check if we need to set _reader.BaseStream.Position or not
-                fontNames.Add(System.Text.Encoding.UTF8.GetString(_reader.ReadBytes(indexElem.len)));
+                fontNames.Add(Encoding.UTF8.GetString(_reader.ReadBytes(indexElem.len), 0, indexElem.len));
             }
 
             //
@@ -798,7 +798,7 @@ namespace Typography.OpenFont.CFF
                 //TODO: review here again, 
                 //check if we need to set _reader.BaseStream.Position or not 
                 //TODO: Is Charsets.ISO_8859_1 Encoding supported in .netcore 
-                _uniqueStringTable[i] = System.Text.Encoding.UTF8.GetString(_reader.ReadBytes(offset.len));
+                _uniqueStringTable[i] = Encoding.UTF8.GetString(_reader.ReadBytes(offset.len), 0, offset.len);
             }
 
             _cff1FontSet._uniqueStringTable = _uniqueStringTable;

--- a/Typography.OpenFont/Tables.CFF/CffEvaluationEngine.cs
+++ b/Typography.OpenFont/Tables.CFF/CffEvaluationEngine.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 
 namespace Typography.OpenFont.CFF
@@ -1154,55 +1155,55 @@ namespace Typography.OpenFont.CFF
 
         public void Op_Abs()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Abs));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Abs));
         }
         public void Op_Add()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Add));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Add));
         }
         public void Op_Sub()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Sub));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Sub));
         }
         public void Op_Div()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Div));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Div));
         }
         public void Op_Neg()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Neg));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Neg));
         }
         public void Op_Random()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Random));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Random));
         }
         public void Op_Mul()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Mul));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Mul));
         }
         public void Op_Sqrt()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Sqrt));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Sqrt));
         }
         public void Op_Drop()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Drop));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Drop));
         }
         public void Op_Exch()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Exch));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Exch));
         }
         public void Op_Index()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Index));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Index));
         }
         public void Op_Roll()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Roll));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Roll));
         }
         public void Op_Dup()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Dup));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Dup));
         }
 
 
@@ -1222,34 +1223,34 @@ namespace Typography.OpenFont.CFF
 
         public void Put()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Put));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Put));
         }
         public void Get()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Get));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Get));
         }
 
         //-------------------------
         //4.6: Conditional  
         public void Op_And()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_And));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_And));
         }
         public void Op_Or()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Or));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Or));
         }
         public void Op_Not()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Not));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Not));
         }
         public void Op_Eq()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Eq));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_Eq));
         }
         public void Op_IfElse()
         {
-            Console.WriteLine("NOT_IMPLEMENT:" + nameof(Op_IfElse));
+            Debug.WriteLine("NOT_IMPLEMENT:" + nameof(Op_IfElse));
         }
         public double Pop()
         {

--- a/Typography.OpenFont/Tables.CFF/Type2CharStringParser.cs
+++ b/Typography.OpenFont/Tables.CFF/Type2CharStringParser.cs
@@ -5,8 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
-using System.Text;
 
 namespace Typography.OpenFont.CFF
 {
@@ -427,7 +427,7 @@ namespace Typography.OpenFont.CFF
                         {
                             if (b0 < 32)
                             {
-                                Console.WriteLine("err!:" + b0);
+                                Debug.WriteLine("err!:" + b0);
                                 return null;
                             }
                             insts.AddInt(ReadIntegerNumber(b0));
@@ -478,7 +478,7 @@ namespace Typography.OpenFont.CFF
                                 default:
                                     if (b0 <= 38)
                                     {
-                                        Console.WriteLine("err!:" + b0);
+                                        Debug.WriteLine("err!:" + b0);
                                         return null;
                                     }
                                     break;

--- a/Typography.OpenFont/Tables/Post.cs
+++ b/Typography.OpenFont/Tables/Post.cs
@@ -151,7 +151,7 @@ namespace Typography.OpenFont.Tables
                         //                        }
                         //#endif
 
-                        _glyphNames.Add(glyphNameIndex, System.Text.Encoding.UTF8.GetString(reader.ReadBytes(len)));
+                        _glyphNames.Add(glyphNameIndex, System.Text.Encoding.UTF8.GetString(reader.ReadBytes(len), 0, len));
                     }
                 }
             }


### PR DESCRIPTION
For Typography.MsdfGen, .NET Standard 1.0 can be used because it does not need FileStream etc like OpenFont or TextBreak.

Also changed Console to Debug because they are simply more accurate.
