### PR TITLE
Use InvariantCulture everywhere

### DIFF
--- a/Typography.OpenFont/AdditionalInfo/AdobeGlyphList.cs
+++ b/Typography.OpenFont/AdditionalInfo/AdobeGlyphList.cs
@@ -108,25 +108,25 @@ namespace Typography.OpenFont
                             default: throw new System.Exception("??");
                             case 1:
                                 unicodeValue =
-                                    int.Parse(unicodeParts[0].Trim(), System.Globalization.NumberStyles.HexNumber);
+                                    int.Parse(unicodeParts[0], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture);
                                 break;
                             case 2:
                                 unicodeValue =
-                                    int.Parse(unicodeParts[0].Trim(), System.Globalization.NumberStyles.HexNumber) << 8 |
-                                    int.Parse(unicodeParts[1].Trim(), System.Globalization.NumberStyles.HexNumber);
+                                    int.Parse(unicodeParts[0], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture) << 8 |
+                                    int.Parse(unicodeParts[1], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture);
                                 break;
                             case 3:
                                 unicodeValue =
-                                  int.Parse(unicodeParts[0].Trim(), System.Globalization.NumberStyles.HexNumber) << 16 |
-                                  int.Parse(unicodeParts[1].Trim(), System.Globalization.NumberStyles.HexNumber) << 8 |
-                                  int.Parse(unicodeParts[2].Trim(), System.Globalization.NumberStyles.HexNumber);
+                                  int.Parse(unicodeParts[0], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture) << 16 |
+                                  int.Parse(unicodeParts[1], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture) << 8 |
+                                  int.Parse(unicodeParts[2], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture);
                                 break;
                             case 4:
                                 unicodeValue =
-                                  int.Parse(unicodeParts[0].Trim(), System.Globalization.NumberStyles.HexNumber) << 24 |
-                                  int.Parse(unicodeParts[1].Trim(), System.Globalization.NumberStyles.HexNumber) << 16 |
-                                  int.Parse(unicodeParts[2].Trim(), System.Globalization.NumberStyles.HexNumber) << 8 |
-                                  int.Parse(unicodeParts[3].Trim(), System.Globalization.NumberStyles.HexNumber);
+                                  int.Parse(unicodeParts[0], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture) << 24 |
+                                  int.Parse(unicodeParts[1], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture) << 16 |
+                                  int.Parse(unicodeParts[2], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture) << 8 |
+                                  int.Parse(unicodeParts[3], System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture);
                                 break;
                         }
                          

--- a/Typography.OpenFont/AdditionalInfo/MacPostFormat1.cs
+++ b/Typography.OpenFont/AdditionalInfo/MacPostFormat1.cs
@@ -34,7 +34,7 @@ namespace Typography.OpenFont
                             {
                                 throw new System.NotSupportedException();
                             }
-                            if (int.TryParse(key_value[0], out int index))
+                            if (int.TryParse(key_value[0], System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out int index))
                             {
 #if DEBUG
                                 if (index < 0 || index > 258)


### PR DESCRIPTION
The HexNumber style allows preceding and trailing white spaces, so no need to trim the string.