### PR TITLE
Fix NotSupportedException when multiple out of range chars are encountered

### DIFF
--- a/Typography.TextBreak/Typography.TextBreak/EngBreakingEngine.cs
+++ b/Typography.TextBreak/Typography.TextBreak/EngBreakingEngine.cs
@@ -44,6 +44,7 @@ namespace Typography.TextBreak
             LexState lexState = LexState.Init;
             int endBefore = start + len;
 
+            breakBounds.startIndex = start;
 
             char first = (char)1;
             char last = (char)255;


### PR DESCRIPTION
**Note:** EngBreakingEngine claims to support char codes 1 to 255, however it cannot handle when char.IsControl(c). When char.IsControl(c) is handled, then all chars between 1 and 255 will not cause NotSupportedExceptions.
