### PR TITLE
Use NuGet package instead of .NET Framework 2.0 version in TextBreakerTests

### DIFF
--- a/Typography.TextBreak/Typography.TextBreak.UnitTests/TextBreakTests.csproj
+++ b/Typography.TextBreak/Typography.TextBreak.UnitTests/TextBreakTests.csproj
@@ -49,7 +49,16 @@
       <HintPath>$(SolutionDir)\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Buffers.4.5.0\lib\netstandard1.1\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.1\lib\netstandard1.1\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.1\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
@@ -61,13 +70,8 @@
     <Compile Include="WordKindTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\System.Memory\System.Memory.csproj">
-      <Project>{3f501b34-9e57-4610-8087-208f3a53cfb7}</Project>
-      <Name>System.Memory</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Typography.TextBreak/Typography.TextBreak.UnitTests/app.config
+++ b/Typography.TextBreak/Typography.TextBreak.UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Typography.TextBreak/Typography.TextBreak.UnitTests/packages.config
+++ b/Typography.TextBreak/Typography.TextBreak.UnitTests/packages.config
@@ -2,5 +2,8 @@
 <packages>
   <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net45" />
   <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net45" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net45" />
+  <package id="System.Memory" version="4.5.1" targetFramework="net45" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Typography.TextBreak/Typography.TextBreak/CustomBreaker.cs
+++ b/Typography.TextBreak/Typography.TextBreak/CustomBreaker.cs
@@ -77,9 +77,9 @@ namespace Typography.TextBreak
         public void BreakWords(string inputstr, ICollection<BreakAtInfo> outputBreakAtList) =>
             BreakWords(inputstr.AsSpan(), outputBreakAtList);
 
-        private static BreakAtInfo BreakAtToSpan(BreakSpan span) => new BreakAtInfo(span.startAt + span.len, span.wordKind);
+        private static BreakAtInfo BreakSpanToAt(BreakSpan span) => new BreakAtInfo(span.startAt + span.len, span.wordKind);
         public void BreakWords(ReadOnlySpan<char> charBuff, ICollection<BreakAtInfo> outputBreakAtList) =>
-            BreakWords(inputstr, span => outputBreakAtList.Add(BreakAtToSpan(span)));
+            BreakWords(inputstr, span => outputBreakAtList.Add(BreakSpanToAt(span)));
 
         public void BreakWords(ReadOnlySpan<char> charBuff, ICollection<BreakSpan> outputBreakSpanList) =>
             BreakWords(charBuff, outputBreakSpanList.Add);

--- a/Typography.TextBreak/Typography.TextBreak/CustomBreaker.cs
+++ b/Typography.TextBreak/Typography.TextBreak/CustomBreaker.cs
@@ -75,14 +75,15 @@ namespace Typography.TextBreak
             BreakWords(inputstr.AsSpan(), outputBreakSpanList);
 
         public void BreakWords(string inputstr, ICollection<BreakAtInfo> outputBreakAtList) =>
-            BreakWords(inputstr.AsSpan(), span => outputBreakAtList.Add(BreakAtToSpan(span)));
+            BreakWords(inputstr.AsSpan(), outputBreakAtList);
 
-        delegate BreakAtInfo BreakSpanToAtDelegate(BreakSpan span);
-        readonly BreakSpanToAtDelegate BreakAtToSpan = span => new BreakAtInfo(span.startAt + span.len, span.wordKind);
+        private static BreakAtInfo BreakAtToSpan(BreakSpan span) => new BreakAtInfo(span.startAt + span.len, span.wordKind);
+        public void BreakWords(ReadOnlySpan<char> charBuff, ICollection<BreakAtInfo> outputBreakAtList) =>
+            BreakWords(inputstr, span => outputBreakAtList.Add(BreakAtToSpan(span)));
 
         public void BreakWords(ReadOnlySpan<char> charBuff, ICollection<BreakSpan> outputBreakSpanList) =>
             BreakWords(charBuff, outputBreakSpanList.Add);
-
+        
         public void BreakWords(ReadOnlySpan<char> charBuff, Action<BreakSpan> outputBreakSpanAction)
         {
             //convert to char buffer 


### PR DESCRIPTION
So that I can use it without referencing the .NET Framework 2.0 version of System.Memory