### PR TITLE
GPOS updates

### DIFF
--- a/Typography.GlyphLayout/GlyphLayout.cs
+++ b/Typography.GlyphLayout/GlyphLayout.cs
@@ -463,7 +463,7 @@ namespace Typography.TextLayout
             }
 
             PositionTechnique posTech = this.PositionTechnique;
-            if (EnableGpos && _gpos != null && glyphs.Count > 1 && posTech == PositionTechnique.OpenFont)
+            if (EnableGpos && _gpos != null && glyphs.Count > 0 && posTech == PositionTechnique.OpenFont)
             {
                 _gpos.DoGlyphPosition(_glyphPositions);
             }

--- a/Typography.OpenFont/Tables.AdvancedLayout/GPOS.Others.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GPOS.Others.cs
@@ -836,18 +836,19 @@ namespace Typography.OpenFont.Tables
             //struct 	PosLookupRecord[PosCount] 	Array of positioning lookups-in design order
             //----------------------
 
-            PosClassRule[] _posClassRules;
+            public PosClassRule[] PosClassRules;
+
             void ReadFrom(BinaryReader reader)
             {
                 long tableStartAt = reader.BaseStream.Position;
                 //
                 ushort posClassRuleCnt = reader.ReadUInt16();
                 ushort[] posClassRuleOffsets = Utils.ReadUInt16Array(reader, posClassRuleCnt);
-                _posClassRules = new PosClassRule[posClassRuleCnt];
+                PosClassRules = new PosClassRule[posClassRuleCnt];
                 for (int i = 0; i < posClassRuleOffsets.Length; ++i)
                 {
                     //move to and read                     
-                    _posClassRules[i] = PosClassRule.CreateFrom(reader, tableStartAt + posClassRuleOffsets[i]);
+                    PosClassRules[i] = PosClassRule.CreateFrom(reader, tableStartAt + posClassRuleOffsets[i]);
                 }
             }
 
@@ -860,10 +861,11 @@ namespace Typography.OpenFont.Tables
                 return posClassSetTable;
             }
         }
+
         class PosClassRule
         {
-            PosLookupRecord[] _posLookupRecords;
-            ushort[] _inputGlyphIds;
+            public PosLookupRecord[] PosLookupRecords;
+            public ushort[] InputGlyphIds;
 
             public static PosClassRule CreateFrom(BinaryReader reader, long beginAt)
             {
@@ -875,11 +877,10 @@ namespace Typography.OpenFont.Tables
                 ushort posCount = reader.ReadUInt16();
                 if (glyphCount > 1)
                 {
-                    posClassRule._inputGlyphIds = Utils.ReadUInt16Array(reader, glyphCount - 1);
-
+                    posClassRule.InputGlyphIds = Utils.ReadUInt16Array(reader, glyphCount - 1);
                 }
 
-                posClassRule._posLookupRecords = CreateMultiplePosLookupRecords(reader, posCount);
+                posClassRule.PosLookupRecords = CreateMultiplePosLookupRecords(reader, posCount);
                 return posClassRule;
             }
         }

--- a/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
@@ -157,6 +157,7 @@ namespace Typography.OpenFont.Tables
                         if (cov_index > -1)
                         {
                             var vr = _valueRecords[Format == 1 ? 0 : cov_index];
+                            inputGlyphs.AppendGlyphOffset(i, vr.XPlacement, vr.YPlacement);
                             inputGlyphs.AppendGlyphAdvance(i, vr.XAdvance, 0);
                         }
                     }
@@ -246,14 +247,15 @@ namespace Typography.OpenFont.Tables
                                 //TODO: recheck for vertical writing ... (YAdvance)
                                 if (v1 != null)
                                 {
+                                    inputGlyphs.AppendGlyphOffset(i, v1.XPlacement, v1.YPlacement);
                                     inputGlyphs.AppendGlyphAdvance(i, v1.XAdvance, 0);
                                 }
 
                                 if (v2 != null)
                                 {
+                                    inputGlyphs.AppendGlyphOffset(i + 1, v2.XPlacement, v2.YPlacement);
                                     inputGlyphs.AppendGlyphAdvance(i + 1, v2.XAdvance, 0);
                                 }
-
                             }
                         }
                     }
@@ -308,13 +310,15 @@ namespace Typography.OpenFont.Tables
                                     ValueRecord v1 = pair.value1;
                                     ValueRecord v2 = pair.value2;
 
-                                    if (v1 != null && v1.XAdvance != 0)
+                                    if (v1 != null)
                                     {
+                                        inputGlyphs.AppendGlyphOffset(i, v1.XPlacement, v1.YPlacement);
                                         inputGlyphs.AppendGlyphAdvance(i, v1.XAdvance, 0);
                                     }
 
                                     if (v2 != null)
                                     {
+                                        inputGlyphs.AppendGlyphOffset(i + 1, v2.XPlacement, v2.YPlacement);
                                         inputGlyphs.AppendGlyphAdvance(i + 1, v2.XAdvance, 0);
                                     }
                                 }

--- a/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
@@ -951,7 +951,7 @@ namespace Typography.OpenFont.Tables
                             ushort[] posClassSetOffsets = Utils.ReadUInt16Array(reader, posClassSetCount);
 
                             var subTable = new LkSubTableType7Fmt2();
-                            subTable.ClassDefOffset = classDefOffset;
+                            subTable.ClassDef = ClassDefTable.CreateFrom(reader, subTableStartAt + classDefOffset);
 
                             PosClassSetTable[] posClassSetTables = new PosClassSetTable[posClassSetCount];
                             subTable.PosClassSetTables = posClassSetTables;
@@ -996,7 +996,7 @@ namespace Typography.OpenFont.Tables
 
             class LkSubTableType7Fmt2 : LookupSubTable
             {
-                public ushort ClassDefOffset { get; set; }
+                public ClassDefTable ClassDef { get; set; }
                 public CoverageTable CoverageTable { get; set; }
                 public PosClassSetTable[] PosClassSetTables { get; set; }
                 public override void DoGlyphPosition(IGlyphPositions inputGlyphs, int startAt, int len)
@@ -1033,10 +1033,6 @@ namespace Typography.OpenFont.Tables
                 }
                 public CoverageTable CoverageTable { get; set; }
                 public PosClassSetTable[] PosClassSetTables { get; set; }
-
-                public ushort BacktrackClassDefOffset { get; set; }
-                public ushort InputClassDefOffset { get; set; }
-                public ushort LookaheadClassDefOffset { get; set; }
 
                 public ClassDefTable BackTrackClassDef { get; set; }
                 public ClassDefTable InputClassDef { get; set; }
@@ -1116,13 +1112,8 @@ namespace Typography.OpenFont.Tables
                             ushort[] chainPosClassSetOffsetArray = Utils.ReadUInt16Array(reader, chainPosClassSetCnt);
 
                             LkSubTableType8Fmt2 subTable = new LkSubTableType8Fmt2();
-                            subTable.BacktrackClassDefOffset = backTrackClassDefOffset;
                             subTable.BackTrackClassDef = ClassDefTable.CreateFrom(reader, subTableStartAt + backTrackClassDefOffset);
-
-                            subTable.InputClassDefOffset = inputClassDefOffset;
                             subTable.InputClassDef = ClassDefTable.CreateFrom(reader, subTableStartAt + inputClassDefOffset);
-
-                            subTable.LookaheadClassDefOffset = lookadheadClassDefOffset;
                             subTable.LookaheadClassDef = ClassDefTable.CreateFrom(reader, subTableStartAt + lookadheadClassDefOffset);
 
                             //----------

--- a/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
@@ -1103,7 +1103,46 @@ namespace Typography.OpenFont.Tables
 
                 public override void DoGlyphPosition(IGlyphPositions inputGlyphs, int startAt, int len)
                 {
-                    Utils.WarnUnimplemented("GPOS Lookup Sub Table Type 8 Format 3");
+                    startAt = Math.Max(startAt, BacktrackCoverages.Length);
+                    int lim = Math.Min(startAt + len, inputGlyphs.Count) - (InputGlyphCoverages.Length - 1) - LookaheadCoverages.Length;
+                    for (int pos = startAt; pos < lim; ++pos)
+                    {
+                        DoGlyphPositionAt(inputGlyphs, pos);
+                    }
+                }
+
+                protected void DoGlyphPositionAt(IGlyphPositions inputGlyphs, int pos)
+                {
+                    // Check all coverages: if any of them does not match, abort substitution
+                    for (int i = 0; i < InputGlyphCoverages.Length; ++i)
+                    {
+                        if (InputGlyphCoverages[i].FindPosition(inputGlyphs.GetGlyph(pos + i, out var unused)) < 0)
+                        {
+                            return;
+                        }
+                    }
+
+                    for (int i = 0; i < BacktrackCoverages.Length; ++i)
+                    {
+                        if (BacktrackCoverages[i].FindPosition(inputGlyphs.GetGlyph(pos - 1 - i, out var unused)) < 0)
+                        {
+                            return;
+                        }
+                    }
+
+                    for (int i = 0; i < LookaheadCoverages.Length; ++i)
+                    {
+                        if (LookaheadCoverages[i].FindPosition(inputGlyphs.GetGlyph(pos + InputGlyphCoverages.Length + i, out var unused)) < 0)
+                        {
+                            return;
+                        }
+                    }
+
+                    foreach (var plr in PosLookupRecords)
+                    {
+                        var lookup = OwnerGPos.LookupList[plr.lookupListIndex];
+                        lookup.DoGlyphPosition(inputGlyphs, pos + plr.seqIndex, InputGlyphCoverages.Length - plr.seqIndex);
+                    }
                 }
             }
 

--- a/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
@@ -951,15 +951,19 @@ namespace Typography.OpenFont.Tables
                             ushort[] posClassSetOffsets = Utils.ReadUInt16Array(reader, posClassSetCount);
 
                             var subTable = new LkSubTableType7Fmt2();
+                            subTable.CoverageTable = CoverageTable.CreateFrom(reader, subTableStartAt + coverageOffset);
                             subTable.ClassDef = ClassDefTable.CreateFrom(reader, subTableStartAt + classDefOffset);
 
                             PosClassSetTable[] posClassSetTables = new PosClassSetTable[posClassSetCount];
                             subTable.PosClassSetTables = posClassSetTables;
                             for (int n = 0; n < posClassSetCount; ++n)
                             {
-                                posClassSetTables[n] = PosClassSetTable.CreateFrom(reader, subTableStartAt + posClassSetOffsets[n]);
+                                ushort offset = posClassSetOffsets[n];
+                                if (offset > 0)
+                                {
+                                    posClassSetTables[n] = PosClassSetTable.CreateFrom(reader, subTableStartAt + offset);
+                                }
                             }
-                            subTable.CoverageTable = CoverageTable.CreateFrom(reader, subTableStartAt + coverageOffset);
                             return subTable;
                         }
                     case 3:

--- a/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
@@ -604,16 +604,16 @@ namespace Typography.OpenFont.Tables
                             int baseFound = BaseCoverageTable.FindPosition(inputGlyphs.GetGlyph(i - 1, out ushort prev_glyph_adv_w));
                             if (baseFound > -1)
                             {
+                                inputGlyphs.GetOffset(i - 1, out short prev_glyph_xoffset, out short prev_glyph_yoffset);
                                 ushort markClass = this.MarkArrayTable.GetMarkClass(markFound);
                                 //find anchor on base glyph
                                 AnchorPoint markAnchorPoint = this.MarkArrayTable.GetAnchorPoint(markFound);
                                 BaseRecord baseRecord = BaseArrayTable.GetBaseRecords(baseFound);
                                 AnchorPoint basePointForMark = baseRecord.anchors[markClass];
-                                inputGlyphs.AppendGlyphOffset(
-                                    i,
-                                    (short)((-prev_glyph_adv_w + basePointForMark.xcoord - markAnchorPoint.xcoord)),
-                                    (short)(basePointForMark.ycoord - markAnchorPoint.ycoord)
-                                    );
+                                int xoffset = prev_glyph_xoffset - prev_glyph_adv_w
+                                            + basePointForMark.xcoord - markAnchorPoint.xcoord;
+                                int yoffset = basePointForMark.ycoord - markAnchorPoint.ycoord;
+                                inputGlyphs.AppendGlyphOffset(i, (short)xoffset, (short)yoffset);
                             }
                         }
                         xpos += glyph_advW;
@@ -1093,6 +1093,7 @@ namespace Typography.OpenFont.Tables
                     Utils.WarnUnimplemented("GPOS Lookup Sub Table Type 8 Format 2");
                 }
             }
+
             class LkSubTableType8Fmt3 : LookupSubTable
             {
                 public CoverageTable[] BacktrackCoverages { get; set; }

--- a/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
+++ b/Typography.OpenFont/Tables.AdvancedLayout/GPOS.cs
@@ -1028,7 +1028,7 @@ namespace Typography.OpenFont.Tables
                         foreach (var rule in PosClassSetTables[glyph1_class].PosClassRules)
                         {
                             var glyphIds = rule.InputGlyphIds;
-                            bool success = false;
+                            int matches = 0;
                             for (int n = 0; n < glyphIds.Length && i + 1 + n < lim; ++n)
                             {
                                 ushort glyphn_index = inputGlyphs.GetGlyph(i + 1 + n, out unused);
@@ -1037,16 +1037,16 @@ namespace Typography.OpenFont.Tables
                                 {
                                     break;
                                 }
-
-                                if (n == glyphIds.Length - 1)
-                                {
-                                    success = true;
-                                    Utils.WarnUnimplemented("GPOS Lookup Sub Table Type 7 Format 2");
-                                }
+                                ++matches;
                             }
 
-                            if (success)
+                            if (matches == glyphIds.Length)
                             {
+                                foreach (var plr in rule.PosLookupRecords)
+                                {
+                                    var lookup = OwnerGPos.LookupList[plr.lookupListIndex];
+                                    lookup.DoGlyphPosition(inputGlyphs, i + plr.seqIndex, glyphIds.Length - plr.seqIndex);
+                                }
                                 break;
                             }
                         }


### PR DESCRIPTION
Hi! Here is some long overdue work on GPOS tables to improve Emoji support for family ligatures. Not complete, but it seems to cover everything in the current Emoji standard. There is still a problem with emojis such as `|👨‍👧‍👦‍👦|` (caused by subtable 7 format 2 not fully implemented, though I already did almost all of the work) but these are Windows extensions and not part of the Emoji standard AFAIK.

## Before/after with the string `|👨‍👦|👨‍👧‍👦|👨‍👩‍👧‍👦|`:

![image](https://user-images.githubusercontent.com/245089/99911503-21c37780-2cf5-11eb-8584-2d047bb77714.png)
