### PR TITLE
Do not redefine ExtensionAttribute with recent enough .NET frameworks.

### DIFF
--- a/Build/N20/Typography.OpenFont/ExtensionAttribute.cs
+++ b/Build/N20/Typography.OpenFont/ExtensionAttribute.cs
@@ -1,6 +1,6 @@
 ﻿#if NET20
 namespace System.Runtime.CompilerServices
 {
-    public partial class ExtensionAttribute : Attribute { }
+    internal partial class ExtensionAttribute : Attribute { }
 }
 #endif

--- a/Build/N20/Typography.TextBreak/ExtensionAttribute.cs
+++ b/Build/N20/Typography.TextBreak/ExtensionAttribute.cs
@@ -1,6 +1,6 @@
 ﻿#if NET20
 namespace System.Runtime.CompilerServices
 {
-    public partial class ExtensionAttribute : Attribute { }
+    internal partial class ExtensionAttribute : Attribute { }
 }
 #endif

--- a/Build/N20/Typography.TextBreak/ExtensionAttribute.cs
+++ b/Build/N20/Typography.TextBreak/ExtensionAttribute.cs
@@ -1,4 +1,6 @@
-﻿namespace System.Runtime.CompilerServices
+﻿#if NET20
+namespace System.Runtime.CompilerServices
 {
     public partial class ExtensionAttribute : Attribute { }
 }
+#endif


### PR DESCRIPTION
Without this minor fix, building with _e.g._ .NET Framework 4.0 gives the following warning:

    3>CSC : warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'

There is already the same `#if` in `Build/N20/Typography.OpenFont/ExtensionAttribute.cs`.