### PR TITLE
fix: removed incorrect signed cast in Fixed1616 fraction part parsing

### DIFF
--- a/Typography.OpenFont/Tables.CFF/Type2CharStringParser.cs
+++ b/Typography.OpenFont/Tables.CFF/Type2CharStringParser.cs
@@ -57,7 +57,7 @@ namespace Typography.OpenFont.CFF
 
             ///This number is interpreted as a Fixed; that is, a signed number with 16 bits of fraction
             float int_part = (short)((b0 << 8) | b1);
-            float fraction_part = (short)((b2 << 8) | b3) / (float)(1 << 16);
+            float fraction_part = ((b2 << 8) | b3) / (float)(1 << 16);
             return int_part + fraction_part;
         }
 


### PR DESCRIPTION
Previously, the fractional part was cast to a signed short, which caused incorrect interpretation of values when the highest bit of the fraction was set. This resulted in subtle coordinate drift when reconstructing glyph outlines from Type2 charstrings.

The fix removes the unnecessary signed cast and treats the fractional part as an unsigned 16-bit value, aligning with the Fixed1616 specification.

This resolves cumulative errors visible across contour segments.